### PR TITLE
fix: unlock @aws-cdk dependency versions to permit later versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prepare": "npm run build"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "1.113.0",
+    "@aws-cdk/assert": "^1.113.0",
     "@commitlint/cli": "^12.1.4",
     "@commitlint/config-conventional": "^12.1.4",
     "@types/jest": "^26.0.10",
@@ -35,7 +35,7 @@
     "typescript": "~3.9.7"
   },
   "peerDependencies": {
-    "@aws-cdk/core": "1.113.0"
+    "@aws-cdk/core": "^1.113.0"
   },
   "dependencies": {
     "@aws-cdk/aws-certificatemanager": "^1.113.0",
@@ -44,6 +44,6 @@
     "@aws-cdk/aws-route53-targets": "^1.113.0",
     "@aws-cdk/aws-s3": "^1.113.0",
     "@aws-cdk/aws-s3-deployment": "^1.113.0",
-    "@aws-cdk/core": "1.113.0"
+    "@aws-cdk/core": "^1.113.0"
   }
 }


### PR DESCRIPTION
At present, the `@aws-cdk/*` packages are unpinned dependencies, except for a couple which are pinned. This makes it impossible to use them from a consuming application, because the unpinned versions will conflict with the pinned versions.

The solution here is to unpin across the board. Consuming applications should then pin their own dependencies.

This is motivated by this discussion of the alternatives: https://matthewbonig.com/2021/04/06/automating-construct-publishing/ which concludes that the solutions are either to pin everything or unpin everything. We cannot easily pin everything without introducing breaking changes, so I went for "unpin everything"