### PR TITLE
Asset invalidation control

### DIFF
--- a/lib/cdn-site-hosting/cdn-site-hosting-construct.ts
+++ b/lib/cdn-site-hosting/cdn-site-hosting-construct.ts
@@ -88,15 +88,22 @@ export class CdnSiteHostingConstruct extends cdk.Construct {
       // multiple sources with granular cache and invalidation control
       props.sourcesWithDeploymentOptions.forEach(
         ({ sources, distributionPathsToInvalidate, cacheControl }, index) => {
+          const isInvalidationRequired =
+            distributionPathsToInvalidate &&
+            distributionPathsToInvalidate.length > 0;
           new s3deploy.BucketDeployment(
             this,
-            `DeployWithInvalidationControl[${index}]`,
+            `DeployWithInvalidationControl-${index}`,
             {
               cacheControl,
               sources: sources,
               destinationBucket: this.s3Bucket,
-              distribution: this.cloudfrontWebDistribution,
-              distributionPaths: distributionPathsToInvalidate,
+              distribution: isInvalidationRequired
+                ? this.cloudfrontWebDistribution
+                : undefined,
+              distributionPaths: isInvalidationRequired
+                ? distributionPathsToInvalidate
+                : undefined,
             }
           );
         }
@@ -107,7 +114,7 @@ export class CdnSiteHostingConstruct extends cdk.Construct {
         sources: props.sources,
         destinationBucket: this.s3Bucket,
         distribution: this.cloudfrontWebDistribution,
-        distributionPaths: ['/*']
+        distributionPaths: ["/*"],
       });
     }
   }

--- a/lib/cdn-site-hosting/cdn-site-hosting-construct.ts
+++ b/lib/cdn-site-hosting/cdn-site-hosting-construct.ts
@@ -87,16 +87,23 @@ export class CdnSiteHostingConstruct extends cdk.Construct {
     if (props.sourcesWithDeploymentOptions) {
       // multiple sources with granular cache and invalidation control
       props.sourcesWithDeploymentOptions.forEach(
-        ({ sources, distributionPathsToInvalidate, cacheControl }, index) => {
+        (
+          { name, sources, distributionPathsToInvalidate, cacheControl },
+          index
+        ) => {
           const isInvalidationRequired =
             distributionPathsToInvalidate &&
             distributionPathsToInvalidate.length > 0;
+
+          const suffix = name ? name : `${index}`;
+
           new s3deploy.BucketDeployment(
             this,
-            `DeployWithInvalidationControl-${index}`,
+            `DeployWithInvalidationControl-${suffix}`,
             {
               cacheControl,
               sources: sources,
+              prune: false,
               destinationBucket: this.s3Bucket,
               distribution: isInvalidationRequired
                 ? this.cloudfrontWebDistribution

--- a/lib/cdn-site-hosting/cdn-site-hosting-props.ts
+++ b/lib/cdn-site-hosting/cdn-site-hosting-props.ts
@@ -1,0 +1,18 @@
+import * as cdk from "@aws-cdk/core";
+import * as s3deploy from "@aws-cdk/aws-s3-deployment";
+
+export interface SourcesWithDeploymentOptions {
+  sources: s3deploy.ISource[];
+  distributionPathsToInvalidate?: string[];
+  cacheControl?: s3deploy.CacheControl[];
+}
+
+export interface CommonCdnSiteHostingProps {
+  domainName: string;
+  removalPolicy: cdk.RemovalPolicy;
+  siteSubDomain: string;
+  sources?: s3deploy.ISource[];
+  sourcesWithDeploymentOptions?: SourcesWithDeploymentOptions[];
+  websiteErrorDocument: string;
+  websiteIndexDocument: string;
+}

--- a/lib/cdn-site-hosting/cdn-site-hosting-props.ts
+++ b/lib/cdn-site-hosting/cdn-site-hosting-props.ts
@@ -2,6 +2,7 @@ import * as cdk from "@aws-cdk/core";
 import * as s3deploy from "@aws-cdk/aws-s3-deployment";
 
 export interface SourcesWithDeploymentOptions {
+  name?: string;
   sources: s3deploy.ISource[];
   distributionPathsToInvalidate?: string[];
   cacheControl?: s3deploy.CacheControl[];

--- a/lib/cdn-site-hosting/cdn-site-hosting-with-dns-construct.ts
+++ b/lib/cdn-site-hosting/cdn-site-hosting-with-dns-construct.ts
@@ -2,18 +2,11 @@ import * as cdk from "@aws-cdk/core";
 import * as certificatemanager from "@aws-cdk/aws-certificatemanager";
 import * as route53 from "@aws-cdk/aws-route53";
 import * as targets from "@aws-cdk/aws-route53-targets/lib";
-import * as s3deploy from "@aws-cdk/aws-s3-deployment";
 import { CdnSiteHostingConstruct } from "./cdn-site-hosting-construct";
 import { getSiteDomain } from "./utils";
+import { CommonCdnSiteHostingProps } from "./cdn-site-hosting-props";
 
-export interface CdnSiteHostingWithDnsConstructProps {
-  domainName: string;
-  removalPolicy: cdk.RemovalPolicy;
-  siteSubDomain: string;
-  sources: s3deploy.ISource[];
-  websiteErrorDocument: string;
-  websiteIndexDocument: string;
-}
+export type CdnSiteHostingWithDnsConstructProps = CommonCdnSiteHostingProps;
 
 /**
  * Establishes infrastructure to host a static-site or single-page-application in S3 via CloudFront,

--- a/test/cdn-site-hosting/cdn-site-hosting-construct.test.ts
+++ b/test/cdn-site-hosting/cdn-site-hosting-construct.test.ts
@@ -7,10 +7,7 @@ import {
 import * as cdk from "@aws-cdk/core";
 import { Environment, RemovalPolicy, Stack } from "@aws-cdk/core";
 import * as s3deploy from "@aws-cdk/aws-s3-deployment";
-import {
-  CdnSiteHostingConstruct,
-  CdnSiteHostingConstructProps,
-} from "../../lib/cdn-site-hosting";
+import { CdnSiteHostingConstruct } from "../../lib/cdn-site-hosting";
 
 // hosted-zone requires an environment be attached to the Stack
 const testEnv: Environment = {
@@ -26,12 +23,11 @@ const fakeFqdn = `${fakeSiteSubDomain}.${fakeDomain}`;
 describe("CdnSiteHostingConstruct", () => {
   describe("With a provisioned Stack", () => {
     let stack: Stack;
-    let construct: CdnSiteHostingConstruct;
 
     beforeAll(() => {
       const app = new cdk.App();
       stack = new cdk.Stack(app, "TestStack", { env: testEnv });
-      construct = new CdnSiteHostingConstruct(stack, "MyTestConstruct", {
+      new CdnSiteHostingConstruct(stack, "MyTestConstruct", {
         certificateArn: fakeCertificateArn,
         siteSubDomain: fakeSiteSubDomain,
         domainName: fakeDomain,

--- a/test/cdn-site-hosting/cdn-site-hosting-with-dns-construct.test.ts
+++ b/test/cdn-site-hosting/cdn-site-hosting-with-dns-construct.test.ts
@@ -14,7 +14,6 @@ const testEnv: Environment = {
   region: "eu-west-1",
   account: "abcdefg12345",
 };
-const fakeCertificateArn = `arn:aws:acm:${testEnv.region}:${testEnv.account}:certificate/123456789012-1234-1234-1234-12345678`;
 
 const fakeSiteSubDomain = "test";
 const fakeDomain = "example.com";
@@ -23,12 +22,11 @@ const fakeFqdn = `${fakeSiteSubDomain}.${fakeDomain}`;
 describe("CdnSiteHostingWithDnsConstruct", () => {
   describe("With a provisioned Stack", () => {
     let stack: Stack;
-    let construct: CdnSiteHostingWithDnsConstruct;
 
     beforeAll(() => {
       const app = new cdk.App();
       stack = new cdk.Stack(app, "TestStack", { env: testEnv });
-      construct = new CdnSiteHostingWithDnsConstruct(stack, "MyTestConstruct", {
+      new CdnSiteHostingWithDnsConstruct(stack, "MyTestConstruct", {
         siteSubDomain: fakeSiteSubDomain,
         domainName: fakeDomain,
         removalPolicy: RemovalPolicy.DESTROY,


### PR DESCRIPTION
Extends the existing setup to allow multiple assets to be provided, with granular control over their properties for things like 'cache control'.

In the old days, you specified only `sources` and everything cached in the CDN got invalidated on deployment; now you can instead specify `sourcesWithDeploymentOptions`, which permits more granular control over the deployment invalidation.

A full, working example is part of the current work for user-utils-app:

https://github.com/talis/user-utils-app/pull/218/files#diff-1a22218de1adb65f49f030fa5552eaf8424ff321d3dc696df4cb7a70f2ffbf19R38-R102