### PR TITLE
fix: adding in a custom error response so we get 200s instead of 404s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ cdk.out
 
 !test/infra/authenticated-api/routes/route1.js
 !test/infra/authenticated-api/routes/route2.js
+
+# user files
+
+.vscode
+.DS_Store

--- a/lib/cdn-site-hosting/cdn-site-hosting-construct.ts
+++ b/lib/cdn-site-hosting/cdn-site-hosting-construct.ts
@@ -77,6 +77,14 @@ export class CdnSiteHostingConstruct extends cdk.Construct {
             behaviors: [{ isDefaultBehavior: true }],
           },
         ],
+        errorConfigurations: [
+          {
+            errorCode: 404,
+            errorCachingMinTtl: 10,
+            responseCode: 200,
+            responsePagePath: "/index.html",
+          },
+        ],
       }
     );
     new cdk.CfnOutput(this, "DistributionId", {

--- a/lib/cdn-site-hosting/cdn-site-hosting-construct.ts
+++ b/lib/cdn-site-hosting/cdn-site-hosting-construct.ts
@@ -53,7 +53,9 @@ export class CdnSiteHostingConstruct extends cdk.Construct {
     this.s3Bucket = new s3.Bucket(this, "SiteBucket", {
       bucketName: siteDomain,
       websiteIndexDocument: props.websiteIndexDocument,
-      websiteErrorDocument: props.websiteErrorDocument,
+      websiteErrorDocument: props.isRoutedSpa
+        ? props.websiteErrorDocument
+        : undefined,
       publicReadAccess: true,
       removalPolicy: props.removalPolicy,
       autoDeleteObjects: props.removalPolicy === cdk.RemovalPolicy.DESTROY,
@@ -77,13 +79,15 @@ export class CdnSiteHostingConstruct extends cdk.Construct {
             behaviors: [{ isDefaultBehavior: true }],
           },
         ],
-        errorConfigurations: [
-          {
-            errorCode: 404,
-            responseCode: 200,
-            responsePagePath: "/index.html",
-          },
-        ],
+        errorConfigurations: props.isRoutedSpa
+          ? [
+              {
+                errorCode: 404,
+                responseCode: 200,
+                responsePagePath: "/index.html",
+              },
+            ]
+          : undefined,
       }
     );
     new cdk.CfnOutput(this, "DistributionId", {

--- a/lib/cdn-site-hosting/cdn-site-hosting-construct.ts
+++ b/lib/cdn-site-hosting/cdn-site-hosting-construct.ts
@@ -80,7 +80,6 @@ export class CdnSiteHostingConstruct extends cdk.Construct {
         errorConfigurations: [
           {
             errorCode: 404,
-            errorCachingMinTtl: 10,
             responseCode: 200,
             responsePagePath: "/index.html",
           },

--- a/lib/cdn-site-hosting/cdn-site-hosting-construct.ts
+++ b/lib/cdn-site-hosting/cdn-site-hosting-construct.ts
@@ -49,13 +49,18 @@ export class CdnSiteHostingConstruct extends cdk.Construct {
       }
     );
 
+    let websiteErrorDocument: string | undefined = props.websiteErrorDocument
+    if (!websiteErrorDocument) { 
+      websiteErrorDocument = props.isRoutedSpa
+        ? props.websiteIndexDocument
+        : undefined
+    }
+
     // S3 bucket
     this.s3Bucket = new s3.Bucket(this, "SiteBucket", {
       bucketName: siteDomain,
       websiteIndexDocument: props.websiteIndexDocument,
-      websiteErrorDocument: props.isRoutedSpa
-        ? props.websiteErrorDocument
-        : undefined,
+      websiteErrorDocument,
       publicReadAccess: true,
       removalPolicy: props.removalPolicy,
       autoDeleteObjects: props.removalPolicy === cdk.RemovalPolicy.DESTROY,
@@ -84,7 +89,7 @@ export class CdnSiteHostingConstruct extends cdk.Construct {
               {
                 errorCode: 404,
                 responseCode: 200,
-                responsePagePath: "/index.html",
+                responsePagePath: `/${props.websiteIndexDocument}`,
               },
             ]
           : undefined,

--- a/lib/cdn-site-hosting/cdn-site-hosting-construct.ts
+++ b/lib/cdn-site-hosting/cdn-site-hosting-construct.ts
@@ -31,6 +31,10 @@ export class CdnSiteHostingConstruct extends cdk.Construct {
   ) {
     super(scope, id);
 
+    if (props.websiteIndexDocument[0] === "/") {
+      throw Error("leading slashes are not allowed in websiteIndexDocument");
+    }
+
     validateProps(props);
 
     const siteDomain = getSiteDomain(props);

--- a/lib/cdn-site-hosting/cdn-site-hosting-construct.ts
+++ b/lib/cdn-site-hosting/cdn-site-hosting-construct.ts
@@ -49,11 +49,11 @@ export class CdnSiteHostingConstruct extends cdk.Construct {
       }
     );
 
-    let websiteErrorDocument: string | undefined = props.websiteErrorDocument
-    if (!websiteErrorDocument) { 
+    let websiteErrorDocument: string | undefined = props.websiteErrorDocument;
+    if (!websiteErrorDocument) {
       websiteErrorDocument = props.isRoutedSpa
         ? props.websiteIndexDocument
-        : undefined
+        : undefined;
     }
 
     // S3 bucket

--- a/lib/cdn-site-hosting/cdn-site-hosting-construct.ts
+++ b/lib/cdn-site-hosting/cdn-site-hosting-construct.ts
@@ -31,7 +31,7 @@ export class CdnSiteHostingConstruct extends cdk.Construct {
   ) {
     super(scope, id);
 
-    if (props.websiteIndexDocument[0] === "/") {
+    if (props.websiteIndexDocument.startsWith("/")) {
       throw Error("leading slashes are not allowed in websiteIndexDocument");
     }
 

--- a/lib/cdn-site-hosting/cdn-site-hosting-props.ts
+++ b/lib/cdn-site-hosting/cdn-site-hosting-props.ts
@@ -15,6 +15,6 @@ export interface CommonCdnSiteHostingProps {
   isRoutedSpa?: boolean;
   sources?: s3deploy.ISource[];
   sourcesWithDeploymentOptions?: SourcesWithDeploymentOptions[];
-  websiteErrorDocument: string;
+  websiteErrorDocument?: string;
   websiteIndexDocument: string;
 }

--- a/lib/cdn-site-hosting/cdn-site-hosting-props.ts
+++ b/lib/cdn-site-hosting/cdn-site-hosting-props.ts
@@ -12,6 +12,7 @@ export interface CommonCdnSiteHostingProps {
   domainName: string;
   removalPolicy: cdk.RemovalPolicy;
   siteSubDomain: string;
+  isRoutedSpa?: boolean;
   sources?: s3deploy.ISource[];
   sourcesWithDeploymentOptions?: SourcesWithDeploymentOptions[];
   websiteErrorDocument: string;

--- a/test/infra/cdn-site-hosting/cdn-site-hosting-construct.test.ts
+++ b/test/infra/cdn-site-hosting/cdn-site-hosting-construct.test.ts
@@ -44,6 +44,7 @@ describe("CdnSiteHostingConstruct", () => {
         haveResource("AWS::S3::Bucket", {
           BucketName: fakeFqdn,
           WebsiteConfiguration: {
+            ErrorDocument: "error.html",
             IndexDocument: "index.html",
           },
         })
@@ -95,7 +96,7 @@ describe("CdnSiteHostingConstruct", () => {
         removalPolicy: RemovalPolicy.DESTROY,
         isRoutedSpa: true,
         sources: [s3deploy.Source.asset("./")],
-        websiteErrorDocument: "error.html",
+        websiteErrorDocument: "",
         websiteIndexDocument: "index.html",
       });
     });
@@ -119,7 +120,8 @@ describe("CdnSiteHostingConstruct", () => {
       expectCDK(stack).to(
         haveResourceLike("AWS::S3::Bucket", {
           WebsiteConfiguration: {
-            ErrorDocument: "error.html",
+            IndexDocument: "index.html",
+            ErrorDocument: "index.html",
           },
         })
       );

--- a/test/infra/cdn-site-hosting/cdn-site-hosting-construct.test.ts
+++ b/test/infra/cdn-site-hosting/cdn-site-hosting-construct.test.ts
@@ -83,6 +83,86 @@ describe("CdnSiteHostingConstruct", () => {
     });
   });
 
+  describe("When no error document is provided", () => {
+    let stack: Stack;
+
+    beforeAll(() => {
+      const app = new cdk.App();
+      stack = new cdk.Stack(app, "TestStack", { env: testEnv });
+      new CdnSiteHostingConstruct(stack, "MyTestConstruct", {
+        certificateArn: fakeCertificateArn,
+        siteSubDomain: fakeSiteSubDomain,
+        domainName: fakeDomain,
+        removalPolicy: RemovalPolicy.DESTROY,
+        sources: [s3deploy.Source.asset("./")],
+        websiteIndexDocument: "index.html",
+      });
+    });
+
+    test("provisions a single S3 bucket with website hosting configured", () => {
+      expectCDK(stack).to(countResources("AWS::S3::Bucket", 1));
+      expectCDK(stack).to(
+        haveResource("AWS::S3::Bucket", {
+          BucketName: fakeFqdn,
+          WebsiteConfiguration: {
+            IndexDocument: "index.html",
+          },
+        })
+      );
+    });
+
+    test("provisions a CloudFront distribution linked to S3", () => {
+      expectCDK(stack).to(countResources("AWS::CloudFront::Distribution", 1));
+      expectCDK(stack).to(
+        haveResourceLike("AWS::CloudFront::Distribution", {
+          DistributionConfig: {
+            Aliases: [fakeFqdn],
+            DefaultRootObject: "index.html",
+            ViewerCertificate: {
+              AcmCertificateArn: fakeCertificateArn,
+            },
+            Origins: [
+              {
+                CustomOriginConfig: {
+                  OriginProtocolPolicy: "http-only",
+                },
+              },
+            ],
+          },
+        })
+      );
+    });
+
+    test("issues a bucket deployment with CloudFront invalidation for the specified sources", () => {
+      expectCDK(stack).to(countResources("Custom::CDKBucketDeployment", 1));
+      expectCDK(stack).to(
+        haveResourceLike("Custom::CDKBucketDeployment", {
+          DistributionPaths: ["/*"],
+        })
+      );
+    });
+  });
+
+  describe("When an invalid index document path is provided", () => {
+    test("provisions a single S3 bucket with website hosting configured", () => {
+      const app = new cdk.App();
+      const stack: Stack = new cdk.Stack(app, "TestStack", { env: testEnv });
+
+      expect(
+        () =>
+          new CdnSiteHostingConstruct(stack, "MyTestConstruct", {
+            certificateArn: fakeCertificateArn,
+            siteSubDomain: fakeSiteSubDomain,
+            domainName: fakeDomain,
+            removalPolicy: RemovalPolicy.DESTROY,
+            sources: [s3deploy.Source.asset("./")],
+            websiteErrorDocument: "error.html",
+            websiteIndexDocument: "/index.html",
+          })
+      ).toThrow("leading slashes are not allowed in websiteIndexDocument");
+    });
+  });
+
   describe("For a routed SPA", () => {
     let stack: Stack;
 
@@ -96,7 +176,6 @@ describe("CdnSiteHostingConstruct", () => {
         removalPolicy: RemovalPolicy.DESTROY,
         isRoutedSpa: true,
         sources: [s3deploy.Source.asset("./")],
-        websiteErrorDocument: "",
         websiteIndexDocument: "index.html",
       });
     });

--- a/test/infra/cdn-site-hosting/cdn-site-hosting-construct.test.ts
+++ b/test/infra/cdn-site-hosting/cdn-site-hosting-construct.test.ts
@@ -44,7 +44,6 @@ describe("CdnSiteHostingConstruct", () => {
         haveResource("AWS::S3::Bucket", {
           BucketName: fakeFqdn,
           WebsiteConfiguration: {
-            ErrorDocument: "error.html",
             IndexDocument: "index.html",
           },
         })
@@ -78,6 +77,50 @@ describe("CdnSiteHostingConstruct", () => {
       expectCDK(stack).to(
         haveResourceLike("Custom::CDKBucketDeployment", {
           DistributionPaths: ["/*"],
+        })
+      );
+    });
+  });
+
+  describe("For a routed SPA", () => {
+    let stack: Stack;
+
+    beforeAll(() => {
+      const app = new cdk.App();
+      stack = new cdk.Stack(app, "TestRoutedSPAStack", { env: testEnv });
+      new CdnSiteHostingConstruct(stack, "MyTestConstruct", {
+        certificateArn: fakeCertificateArn,
+        siteSubDomain: fakeSiteSubDomain,
+        domainName: fakeDomain,
+        removalPolicy: RemovalPolicy.DESTROY,
+        isRoutedSpa: true,
+        sources: [s3deploy.Source.asset("./")],
+        websiteErrorDocument: "error.html",
+        websiteIndexDocument: "index.html",
+      });
+    });
+
+    test("configures a custom error response code override in CloudFront", () => {
+      expectCDK(stack).to(
+        haveResourceLike("AWS::CloudFront::Distribution", {
+          DistributionConfig: {
+            CustomErrorResponses: [
+              {
+                ErrorCode: 404,
+                ResponseCode: 200,
+                ResponsePagePath: "/index.html",
+              },
+            ],
+          },
+        })
+      );
+    });
+    test("configures an error document in S3", () => {
+      expectCDK(stack).to(
+        haveResourceLike("AWS::S3::Bucket", {
+          WebsiteConfiguration: {
+            ErrorDocument: "error.html",
+          },
         })
       );
     });

--- a/test/infra/cdn-site-hosting/cdn-site-hosting-construct.test.ts
+++ b/test/infra/cdn-site-hosting/cdn-site-hosting-construct.test.ts
@@ -244,8 +244,8 @@ describe("CdnSiteHostingConstruct", () => {
       expectCDK(stack).to(
         haveResourceLike("AWS::S3::Bucket", {
           WebsiteConfiguration: {
-            IndexDocument: "error.html",
-            ErrorDocument: "index.html",
+            IndexDocument: "index.html",
+            ErrorDocument: "error.html",
           },
         })
       );

--- a/test/infra/cdn-site-hosting/cdn-site-hosting-with-dns-construct.test.ts
+++ b/test/infra/cdn-site-hosting/cdn-site-hosting-with-dns-construct.test.ts
@@ -93,7 +93,6 @@ describe("CdnSiteHostingWithDnsConstruct", () => {
     });
   });
 
-
   describe("For a routed SPA", () => {
     let stack: Stack;
 

--- a/test/infra/cdn-site-hosting/cdn-site-hosting-with-dns-construct.test.ts
+++ b/test/infra/cdn-site-hosting/cdn-site-hosting-with-dns-construct.test.ts
@@ -51,7 +51,6 @@ describe("CdnSiteHostingWithDnsConstruct", () => {
         haveResource("AWS::S3::Bucket", {
           BucketName: fakeFqdn,
           WebsiteConfiguration: {
-            ErrorDocument: "error.html",
             IndexDocument: "index.html",
           },
         })

--- a/test/infra/cdn-site-hosting/cdn-site-hosting-with-dns-construct.test.ts
+++ b/test/infra/cdn-site-hosting/cdn-site-hosting-with-dns-construct.test.ts
@@ -51,6 +51,7 @@ describe("CdnSiteHostingWithDnsConstruct", () => {
         haveResource("AWS::S3::Bucket", {
           BucketName: fakeFqdn,
           WebsiteConfiguration: {
+            ErrorDocument: "error.html",
             IndexDocument: "index.html",
           },
         })
@@ -87,6 +88,51 @@ describe("CdnSiteHostingWithDnsConstruct", () => {
         haveResourceLike("AWS::Route53::RecordSet", {
           Name: `${fakeFqdn}.`,
           Type: "A",
+        })
+      );
+    });
+  });
+
+
+  describe("For a routed SPA", () => {
+    let stack: Stack;
+
+    beforeAll(() => {
+      const app = new cdk.App();
+      stack = new cdk.Stack(app, "TestRoutedSPAStack", { env: testEnv });
+      new CdnSiteHostingWithDnsConstruct(stack, "MyTestConstruct", {
+        siteSubDomain: fakeSiteSubDomain,
+        domainName: fakeDomain,
+        removalPolicy: RemovalPolicy.DESTROY,
+        isRoutedSpa: true,
+        sources: [s3deploy.Source.asset("./")],
+        websiteErrorDocument: "",
+        websiteIndexDocument: "index.html",
+      });
+    });
+
+    test("configures a custom error response code override in CloudFront", () => {
+      expectCDK(stack).to(
+        haveResourceLike("AWS::CloudFront::Distribution", {
+          DistributionConfig: {
+            CustomErrorResponses: [
+              {
+                ErrorCode: 404,
+                ResponseCode: 200,
+                ResponsePagePath: "/index.html",
+              },
+            ],
+          },
+        })
+      );
+    });
+    test("configures an error document in S3", () => {
+      expectCDK(stack).to(
+        haveResourceLike("AWS::S3::Bucket", {
+          WebsiteConfiguration: {
+            IndexDocument: "index.html",
+            ErrorDocument: "index.html",
+          },
         })
       );
     });

--- a/test/infra/cdn-site-hosting/cdn-site-hosting-with-dns-construct.test.ts
+++ b/test/infra/cdn-site-hosting/cdn-site-hosting-with-dns-construct.test.ts
@@ -206,4 +206,48 @@ describe("CdnSiteHostingWithDnsConstruct", () => {
       );
     });
   });
+
+  describe("For a routed SPA when error document is provided", () => {
+    let stack: Stack;
+
+    beforeAll(() => {
+      const app = new cdk.App();
+      stack = new cdk.Stack(app, "TestRoutedSPAStack", { env: testEnv });
+      new CdnSiteHostingWithDnsConstruct(stack, "MyTestConstruct", {
+        siteSubDomain: fakeSiteSubDomain,
+        domainName: fakeDomain,
+        removalPolicy: RemovalPolicy.DESTROY,
+        isRoutedSpa: true,
+        sources: [s3deploy.Source.asset("./")],
+        websiteErrorDocument: "error.html",
+        websiteIndexDocument: "index.html",
+      });
+    });
+
+    test("configures a custom error response code override in CloudFront", () => {
+      expectCDK(stack).to(
+        haveResourceLike("AWS::CloudFront::Distribution", {
+          DistributionConfig: {
+            CustomErrorResponses: [
+              {
+                ErrorCode: 404,
+                ResponseCode: 200,
+                ResponsePagePath: "/index.html",
+              },
+            ],
+          },
+        })
+      );
+    });
+    test("configures an error document in S3", () => {
+      expectCDK(stack).to(
+        haveResourceLike("AWS::S3::Bucket", {
+          WebsiteConfiguration: {
+            ErrorDocument: "error.html",
+            IndexDocument: "index.html",
+          },
+        })
+      );
+    });
+  });
 });


### PR DESCRIPTION
Apps that rely on client side routing will return a 404 when going to a page other than `/`, this is because that url doesn't correspond to a file in the S3 bucket. 

For example, in Otis going to `/talis/player` would return:

<img width="578" alt="Screenshot 2021-09-15 at 10 21 19" src="https://user-images.githubusercontent.com/304623/133411266-63181dee-7ee7-412d-b23a-9db2503ba2a8.png">

whereas what we want is:

<img width="578" src="https://user-images.githubusercontent.com/304623/133411323-32efac2f-ab81-4df6-aa75-cba532be2d7c.png">

This PR adds in support for a new option called `isRoutedSpa` that's off by default, but when enabled it configures a custom error response in CloudFront so 404s from the backend are replaced with a 200. It also tweaks the S3 configuration to not set an `ErrorDocument` since this should only be needed for SPAs.
