### PR TITLE
fix: install husky and enable commitlint for commit-msg

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx --no-install commitlint --edit $1

--- a/package-lock.json
+++ b/package-lock.json
@@ -6338,6 +6338,12 @@
         "ms": "^2.0.0"
       }
     },
+    "husky": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
+      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
+      "dev": true
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "npm run lint:prettier && npm run lint:eslint",
     "format:prettier": "prettier --write .",
     "format": "npm run format:prettier",
-    "prepare": "npm run build"
+    "prepare": "husky install && npm run build"
   },
   "devDependencies": {
     "@aws-cdk/assert": "^1.128.0",
@@ -29,6 +29,7 @@
     "esbuild": "^0.13.8",
     "eslint": "^7.30.0",
     "eslint-config-prettier": "^8.3.0",
+    "husky": "^7.0.4",
     "jest": "^26.4.2",
     "prettier": "^2.3.2",
     "semantic-release": "^17.4.4",


### PR DESCRIPTION
Installs a `commit-msg` pre-commit hook with husky, to run `commitlint` before committing.

Video evidence of the behaviour:

https://user-images.githubusercontent.com/242248/138475302-f107931a-1948-40e1-992d-f5374c1fb22f.mp4

Ignore all references to the change to rebase/squash-and-merge in the video. I've recorded those for posterity in [this comment](https://github.com/talis/talis-cdk-constructs/pull/15#issuecomment-950992907), but we are not changing the rebase behaviour here.
