### PR TITLE
fix: install pr-lint action for linting PR titles

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,13 @@
+name: Lint PR title
+
+on:
+  pull_request:
+    types: ["opened", "edited", "reopened", "synchronize"]
+
+jobs:
+  pr-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: seferov/pr-lint-action@master
+        with:
+          title-regex: "^(feat|fix|docs|build|chore|ci|style|refactor|perf|test)!?: .*"


### PR DESCRIPTION
When the title is bad:

<img width="913" alt="Screenshot 2021-10-26 at 12 53 33" src="https://user-images.githubusercontent.com/242248/138872399-3b54a7cd-ec0f-4585-89b0-6ea5c70e2584.png">

When the title is good:

<img width="948" alt="Screenshot 2021-10-26 at 12 56 15" src="https://user-images.githubusercontent.com/242248/138872714-10b3a6c8-3ecd-49a3-9399-c628d21fadc6.png">

I tried some other actions, and [the titleLint app](https://github.com/apps/title-lint). The app ran much faster, but also never seemed to run after an update, nor did it seem to ever fail.