### PR TITLE
fix: commitlint pull-request title

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -16,6 +16,6 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "${{ steps.nvm.outputs.NVMRC }}"
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - name: Apply commitlint to the PR title
         run: echo "${{ steps.pr_title.outputs.PR_TITLE }}" | npx --no-install commitlint


### PR DESCRIPTION
This adds a custom Github action to run `commitlint` against the PR title.

### A good PR title

<img width="935" alt="Screenshot 2021-10-26 at 14 26 48" src="https://user-images.githubusercontent.com/242248/138888461-cceb875c-737c-4895-a994-3ae3873d4d5a.png">


### A bad PR title

<img width="927" alt="Screenshot 2021-10-26 at 14 25 08" src="https://user-images.githubusercontent.com/242248/138888126-a3798a68-2ea9-4991-bcbe-26b7a4c82bfc.png">

