### PR TITLE
fix: changes to LambdaWorker and AuthenticatedAPI as we start to use them for real

### DIFF
--- a/lib/authenticated-api/authenticated-api.ts
+++ b/lib/authenticated-api/authenticated-api.ts
@@ -92,8 +92,9 @@ export class AuthenticatedApi extends cdk.Construct {
           functionName: `${props.prefix}${props.name}-${routeProps.name}`,
 
           entry: routeProps.lambdaProps.entry,
-          handler: routeProps.lambdaProps.handler,
           environment: routeProps.lambdaProps.environment,
+          handler: routeProps.lambdaProps.handler,
+          role: routeProps.lambdaProps.role,
 
           // Enforce the following properties
           awsSdkConnectionReuse: true,

--- a/lib/authenticated-api/authenticated-api.ts
+++ b/lib/authenticated-api/authenticated-api.ts
@@ -71,9 +71,9 @@ export class AuthenticatedApi extends cdk.Construct {
         awsSdkConnectionReuse: true,
         runtime: lambda.Runtime.NODEJS_14_X,
         timeout: cdk.Duration.minutes(2),
-        securityGroup: props.securityGroup,
-        vpc: props.vpc,
-        vpcSubnets: props.vpcSubnets,
+        /* securityGroup: props.securityGroup, */
+        /* vpc: props.vpc, */
+        /* vpcSubnets: props.vpcSubnets, */
       }
     );
 
@@ -100,9 +100,9 @@ export class AuthenticatedApi extends cdk.Construct {
           awsSdkConnectionReuse: true,
           runtime: lambda.Runtime.NODEJS_14_X,
           timeout: routeProps.lambdaProps.timeout,
-          securityGroup: props.securityGroup,
-          vpc: props.vpc,
-          vpcSubnets: props.vpcSubnets,
+          /* securityGroup: props.securityGroup, */
+          /* vpc: props.vpc, */
+          /* vpcSubnets: props.vpcSubnets, */
         }
       );
 

--- a/lib/authenticated-api/authenticated-api.ts
+++ b/lib/authenticated-api/authenticated-api.ts
@@ -93,6 +93,7 @@ export class AuthenticatedApi extends cdk.Construct {
 
           entry: routeProps.lambdaProps.entry,
           handler: routeProps.lambdaProps.handler,
+          environment: routeProps.lambdaProps.environment,
 
           // Enforce the following properties
           awsSdkConnectionReuse: true,

--- a/lib/authenticated-api/authenticated-api.ts
+++ b/lib/authenticated-api/authenticated-api.ts
@@ -71,9 +71,9 @@ export class AuthenticatedApi extends cdk.Construct {
         awsSdkConnectionReuse: true,
         runtime: lambda.Runtime.NODEJS_14_X,
         timeout: cdk.Duration.minutes(2),
-        /* securityGroup: props.securityGroup, */
-        /* vpc: props.vpc, */
-        /* vpcSubnets: props.vpcSubnets, */
+        securityGroup: props.securityGroup,
+        vpc: props.vpc,
+        vpcSubnets: props.vpcSubnets,
       }
     );
 
@@ -94,15 +94,14 @@ export class AuthenticatedApi extends cdk.Construct {
           entry: routeProps.lambdaProps.entry,
           environment: routeProps.lambdaProps.environment,
           handler: routeProps.lambdaProps.handler,
-          role: routeProps.lambdaProps.role,
 
           // Enforce the following properties
           awsSdkConnectionReuse: true,
           runtime: lambda.Runtime.NODEJS_14_X,
           timeout: routeProps.lambdaProps.timeout,
-          /* securityGroup: props.securityGroup, */
-          /* vpc: props.vpc, */
-          /* vpcSubnets: props.vpcSubnets, */
+          securityGroup: props.securityGroup,
+          vpc: props.vpc,
+          vpcSubnets: props.vpcSubnets,
         }
       );
 

--- a/lib/authenticated-api/authenticated-api.ts
+++ b/lib/authenticated-api/authenticated-api.ts
@@ -108,7 +108,7 @@ export class AuthenticatedApi extends cdk.Construct {
 
       if (routeProps.lambdaProps.policyStatements) {
         for (const statement of routeProps.lambdaProps.policyStatements) {
-          routeLambda.role?.addToPolicy(statement)
+          routeLambda.role?.addToPolicy(statement);
         }
       }
 

--- a/lib/authenticated-api/authenticated-api.ts
+++ b/lib/authenticated-api/authenticated-api.ts
@@ -142,9 +142,9 @@ export class AuthenticatedApi extends cdk.Construct {
       const durationMetric = routeLambda.metric("Duration");
       const durationAlarm = new cloudwatch.Alarm(
         this,
-        `${props.name}-${routeProps.name}-duration-alarm`,
+        `${props.prefix}${props.name}-${routeProps.name}-duration-alarm`,
         {
-          alarmName: `${props.name}-${routeProps.name}-duration-alarm`,
+          alarmName: `${props.prefix}${props.name}-${routeProps.name}-duration-alarm`,
           alarmDescription: `Alarm if duration of lambda for route ${
             props.name
           }-${
@@ -175,9 +175,9 @@ export class AuthenticatedApi extends cdk.Construct {
 
     const routeLatencyAlarm = new cloudwatch.Alarm(
       this,
-      `${props.name}-latency-alarm`,
+      `${props.prefix}${props.name}-latency-alarm`,
       {
-        alarmName: `${props.name}-latency-alarm`,
+        alarmName: `${props.prefix}${props.name}-latency-alarm`,
         alarmDescription: `Alarm if latency on api ${
           props.name
         } exceeds ${latencyThreshold.toMilliseconds()} milliseconds`,

--- a/lib/authenticated-api/authenticated-api.ts
+++ b/lib/authenticated-api/authenticated-api.ts
@@ -106,6 +106,12 @@ export class AuthenticatedApi extends cdk.Construct {
         }
       );
 
+      if (routeProps.lambdaProps.policyStatements) {
+        for (const statement of routeProps.lambdaProps.policyStatements) {
+          routeLambda.role?.addToPolicy(statement)
+        }
+      }
+
       const integration = new integrations.LambdaProxyIntegration({
         handler: routeLambda,
       });

--- a/lib/authenticated-api/route-lambda-props.ts
+++ b/lib/authenticated-api/route-lambda-props.ts
@@ -10,6 +10,7 @@ export interface RouteLambdaProps {
 
   lambdaProps: {
     entry: string;
+    environment?: { [key: string]: string };
     handler: string;
     timeout: cdk.Duration;
   };

--- a/lib/authenticated-api/route-lambda-props.ts
+++ b/lib/authenticated-api/route-lambda-props.ts
@@ -1,5 +1,6 @@
 import * as apigatewayv2 from "@aws-cdk/aws-apigatewayv2";
 import * as cdk from "@aws-cdk/core";
+import * as iam from "@aws-cdk/aws-iam";
 
 export interface RouteLambdaProps {
   name: string;
@@ -12,6 +13,7 @@ export interface RouteLambdaProps {
     entry: string;
     environment?: { [key: string]: string };
     handler: string;
+    role?: iam.IRole;
     timeout: cdk.Duration;
   };
 

--- a/lib/authenticated-api/route-lambda-props.ts
+++ b/lib/authenticated-api/route-lambda-props.ts
@@ -14,7 +14,6 @@ export interface RouteLambdaProps {
     environment?: { [key: string]: string };
     handler: string;
     policyStatements?: iam.PolicyStatement[];
-    role?: iam.IRole;
     timeout: cdk.Duration;
   };
 

--- a/lib/authenticated-api/route-lambda-props.ts
+++ b/lib/authenticated-api/route-lambda-props.ts
@@ -13,6 +13,7 @@ export interface RouteLambdaProps {
     entry: string;
     environment?: { [key: string]: string };
     handler: string;
+    policyStatements?: [ iam.PolicyStatement ];
     role?: iam.IRole;
     timeout: cdk.Duration;
   };

--- a/lib/authenticated-api/route-lambda-props.ts
+++ b/lib/authenticated-api/route-lambda-props.ts
@@ -13,7 +13,7 @@ export interface RouteLambdaProps {
     entry: string;
     environment?: { [key: string]: string };
     handler: string;
-    policyStatements?: [ iam.PolicyStatement ];
+    policyStatements?: iam.PolicyStatement[];
     role?: iam.IRole;
     timeout: cdk.Duration;
   };

--- a/lib/lambda-worker/lambda-worker-props.ts
+++ b/lib/lambda-worker/lambda-worker-props.ts
@@ -15,7 +15,7 @@ export interface LambdaWorkerProps {
     entry: string;
     environment?: { [key: string]: string };
     memorySize: number; // LambdaWorker will set a minimum memory size of 1024
-    policyStatements?: [ iam.PolicyStatement ];
+    policyStatements?: iam.PolicyStatement[];
     reservedConcurrentExecutions?: number;
     retryAttempts?: number;
     role?: iam.IRole;

--- a/lib/lambda-worker/lambda-worker-props.ts
+++ b/lib/lambda-worker/lambda-worker-props.ts
@@ -18,7 +18,6 @@ export interface LambdaWorkerProps {
     policyStatements?: iam.PolicyStatement[];
     reservedConcurrentExecutions?: number;
     retryAttempts?: number;
-    role?: iam.IRole;
     securityGroup?: ec2.ISecurityGroup;
     timeout: cdk.Duration;
     vpc: ec2.IVpc;

--- a/lib/lambda-worker/lambda-worker-props.ts
+++ b/lib/lambda-worker/lambda-worker-props.ts
@@ -15,6 +15,7 @@ export interface LambdaWorkerProps {
     entry: string;
     environment?: { [key: string]: string };
     memorySize: number; // LambdaWorker will set a minimum memory size of 1024
+    policies?: [ iam.Policy ];
     reservedConcurrentExecutions?: number;
     retryAttempts?: number;
     role?: iam.IRole;

--- a/lib/lambda-worker/lambda-worker-props.ts
+++ b/lib/lambda-worker/lambda-worker-props.ts
@@ -15,7 +15,7 @@ export interface LambdaWorkerProps {
     entry: string;
     environment?: { [key: string]: string };
     memorySize: number; // LambdaWorker will set a minimum memory size of 1024
-    policies?: [ iam.Policy ];
+    policyStatements?: [ iam.PolicyStatement ];
     reservedConcurrentExecutions?: number;
     retryAttempts?: number;
     role?: iam.IRole;

--- a/lib/lambda-worker/lambda-worker.ts
+++ b/lib/lambda-worker/lambda-worker.ts
@@ -109,11 +109,10 @@ export class LambdaWorker extends cdk.Construct {
       reservedConcurrentExecutions:
         props.lambdaProps.reservedConcurrentExecutions,
       retryAttempts: props.lambdaProps.retryAttempts,
-      /* role: props.lambdaProps.role, */
-      /* securityGroup: props.lambdaProps.securityGroup, */
+      securityGroup: props.lambdaProps.securityGroup,
       timeout: props.lambdaProps.timeout,
-      /* vpc: props.lambdaProps.vpc, */
-      /* vpcSubnets: props.lambdaProps.vpcSubnets, */
+      vpc: props.lambdaProps.vpc,
+      vpcSubnets: props.lambdaProps.vpcSubnets,
 
       // Enforce the following properties
       awsSdkConnectionReuse: true,

--- a/lib/lambda-worker/lambda-worker.ts
+++ b/lib/lambda-worker/lambda-worker.ts
@@ -17,12 +17,16 @@ const MINIMUM_LAMBDA_TIMEOUT = cdk.Duration.seconds(30);
 
 export class LambdaWorker extends cdk.Construct {
 
+  // The ARN of the queue messages for this LambdaWorker to process
+  // should be placed on.
+  public lambdaQueueArn : string;
+
   // The URL of the queue messages for this LambdaWorker to process
   // should be placed on. If you have passed in an option subscrip topic,
   // this queue will have automatically been subscribed to that topic.
   // If you have not supplied a topic, then you will need to route
   // messages to the queue at lambdaQueueUrl.
-  public lambdaQueueUrl : string
+  public lambdaQueueUrl : string;
 
   constructor(scope: cdk.Construct, id: string, props: LambdaWorkerProps) {
     super(scope, id);
@@ -76,6 +80,7 @@ export class LambdaWorker extends cdk.Construct {
       deadLetterQueue: { queue: lambdaDLQ, maxReceiveCount: maxReceiveCount },
     });
     this.lambdaQueueUrl = lambdaQueue.queueUrl;
+    this.lambdaQueueArn = lambdaQueue.queueArn;
 
     // If we have specified a topic, then subscribe
     // the main queue to the topic.

--- a/lib/lambda-worker/lambda-worker.ts
+++ b/lib/lambda-worker/lambda-worker.ts
@@ -121,9 +121,9 @@ export class LambdaWorker extends cdk.Construct {
       runtime: lambda.Runtime.NODEJS_14_X,
     });
 
-    if (props.lambdaProps.policies) {
-      for (const policy of props.lambdaProps.policies) {
-        lambdaWorker.role?.attachInlinePolicy(policy);
+    if (props.lambdaProps.policyStatements) {
+      for (const statement of props.lambdaProps.policyStatements) {
+        lambdaWorker.role?.addToPolicy(statement)
       }
     }
 

--- a/lib/lambda-worker/lambda-worker.ts
+++ b/lib/lambda-worker/lambda-worker.ts
@@ -110,7 +110,7 @@ export class LambdaWorker extends cdk.Construct {
       reservedConcurrentExecutions:
         props.lambdaProps.reservedConcurrentExecutions,
       retryAttempts: props.lambdaProps.retryAttempts,
-      role: props.lambdaProps.role,
+      /* role: props.lambdaProps.role, */
       securityGroup: props.lambdaProps.securityGroup,
       timeout: props.lambdaProps.timeout,
       vpc: props.lambdaProps.vpc,
@@ -120,6 +120,12 @@ export class LambdaWorker extends cdk.Construct {
       awsSdkConnectionReuse: true,
       runtime: lambda.Runtime.NODEJS_14_X,
     });
+
+    if (props.lambdaProps.policies) {
+      for (const policy of props.lambdaProps.policies) {
+        lambdaWorker.role?.attachInlinePolicy(policy);
+      }
+    }
 
     // Add main queue and DLQ as event sources to the lambda
     // By default, the main queue is enabled and the DLQ is disabled

--- a/lib/lambda-worker/lambda-worker.ts
+++ b/lib/lambda-worker/lambda-worker.ts
@@ -16,6 +16,14 @@ const MINIMUM_MEMORY_SIZE = 1024;
 const MINIMUM_LAMBDA_TIMEOUT = cdk.Duration.seconds(30);
 
 export class LambdaWorker extends cdk.Construct {
+
+  // The URL of the queue messages for this LambdaWorker to process
+  // should be placed on. If you have passed in an option subscrip topic,
+  // this queue will have automatically been subscribed to that topic.
+  // If you have not supplied a topic, then you will need to route
+  // messages to the queue at lambdaQueueUrl.
+  public lambdaQueueUrl : string
+
   constructor(scope: cdk.Construct, id: string, props: LambdaWorkerProps) {
     super(scope, id);
 
@@ -67,6 +75,7 @@ export class LambdaWorker extends cdk.Construct {
       visibilityTimeout: queueTimeout,
       deadLetterQueue: { queue: lambdaDLQ, maxReceiveCount: maxReceiveCount },
     });
+    this.lambdaQueueUrl = lambdaQueue.queueUrl;
 
     // If we have specified a topic, then subscribe
     // the main queue to the topic.

--- a/lib/lambda-worker/lambda-worker.ts
+++ b/lib/lambda-worker/lambda-worker.ts
@@ -16,17 +16,16 @@ const MINIMUM_MEMORY_SIZE = 1024;
 const MINIMUM_LAMBDA_TIMEOUT = cdk.Duration.seconds(30);
 
 export class LambdaWorker extends cdk.Construct {
-
   // The ARN of the queue messages for this LambdaWorker to process
   // should be placed on.
-  public lambdaQueueArn : string;
+  public lambdaQueueArn: string;
 
   // The URL of the queue messages for this LambdaWorker to process
   // should be placed on. If you have passed in an option subscrip topic,
   // this queue will have automatically been subscribed to that topic.
   // If you have not supplied a topic, then you will need to route
   // messages to the queue at lambdaQueueUrl.
-  public lambdaQueueUrl : string;
+  public lambdaQueueUrl: string;
 
   constructor(scope: cdk.Construct, id: string, props: LambdaWorkerProps) {
     super(scope, id);
@@ -123,17 +122,23 @@ export class LambdaWorker extends cdk.Construct {
 
     if (props.lambdaProps.policyStatements) {
       for (const statement of props.lambdaProps.policyStatements) {
-        lambdaWorker.role?.addToPolicy(statement)
+        lambdaWorker.role?.addToPolicy(statement);
       }
     }
 
     // Add main queue and DLQ as event sources to the lambda
     // By default, the main queue is enabled and the DLQ is disabled
     lambdaWorker.addEventSource(
-      new eventSource.SqsEventSource(lambdaQueue, { enabled: true, batchSize: 1 })
+      new eventSource.SqsEventSource(lambdaQueue, {
+        enabled: true,
+        batchSize: 1,
+      })
     );
     lambdaWorker.addEventSource(
-      new eventSource.SqsEventSource(lambdaDLQ, { enabled: false, batchSize: 1 })
+      new eventSource.SqsEventSource(lambdaDLQ, {
+        enabled: false,
+        batchSize: 1,
+      })
     );
 
     // Add alerting

--- a/lib/lambda-worker/lambda-worker.ts
+++ b/lib/lambda-worker/lambda-worker.ts
@@ -130,10 +130,10 @@ export class LambdaWorker extends cdk.Construct {
     // Add main queue and DLQ as event sources to the lambda
     // By default, the main queue is enabled and the DLQ is disabled
     lambdaWorker.addEventSource(
-      new eventSource.SqsEventSource(lambdaQueue, { enabled: true })
+      new eventSource.SqsEventSource(lambdaQueue, { enabled: true, batchSize: 1 })
     );
     lambdaWorker.addEventSource(
-      new eventSource.SqsEventSource(lambdaDLQ, { enabled: false })
+      new eventSource.SqsEventSource(lambdaDLQ, { enabled: false, batchSize: 1 })
     );
 
     // Add alerting

--- a/lib/lambda-worker/lambda-worker.ts
+++ b/lib/lambda-worker/lambda-worker.ts
@@ -111,10 +111,10 @@ export class LambdaWorker extends cdk.Construct {
         props.lambdaProps.reservedConcurrentExecutions,
       retryAttempts: props.lambdaProps.retryAttempts,
       /* role: props.lambdaProps.role, */
-      securityGroup: props.lambdaProps.securityGroup,
+      /* securityGroup: props.lambdaProps.securityGroup, */
       timeout: props.lambdaProps.timeout,
-      vpc: props.lambdaProps.vpc,
-      vpcSubnets: props.lambdaProps.vpcSubnets,
+      /* vpc: props.lambdaProps.vpc, */
+      /* vpcSubnets: props.lambdaProps.vpcSubnets, */
 
       // Enforce the following properties
       awsSdkConnectionReuse: true,

--- a/test/authenticated-api/authenticated-api.test.ts
+++ b/test/authenticated-api/authenticated-api.test.ts
@@ -51,6 +51,9 @@ describe("AuthenticatedApi", () => {
               entry: `${path.resolve(__dirname)}/routes/route1.js`,
               handler: "route",
               timeout: cdk.Duration.seconds(30),
+              environment: {
+                TALIS_ENV_VAR: "some value",
+              },
             },
           },
           {
@@ -61,6 +64,9 @@ describe("AuthenticatedApi", () => {
               entry: `${path.resolve(__dirname)}/routes/route2.js`,
               handler: "route",
               timeout: cdk.Duration.seconds(30),
+              environment: {
+                TALIS_ENV_VAR: "some value",
+              },
             },
             isPublic: true,
           },
@@ -129,6 +135,7 @@ describe("AuthenticatedApi", () => {
           Runtime: "nodejs14.x",
           Environment: {
             Variables: {
+              TALIS_ENV_VAR: "some value",
               AWS_NODEJS_CONNECTION_REUSE_ENABLED: "1",
             },
           },
@@ -143,6 +150,7 @@ describe("AuthenticatedApi", () => {
           Runtime: "nodejs14.x",
           Environment: {
             Variables: {
+              TALIS_ENV_VAR: "some value",
               AWS_NODEJS_CONNECTION_REUSE_ENABLED: "1",
             },
           },

--- a/test/authenticated-api/authenticated-api.test.ts
+++ b/test/authenticated-api/authenticated-api.test.ts
@@ -7,6 +7,7 @@ import {
 import * as apigatewayv2 from "@aws-cdk/aws-apigatewayv2";
 import * as ec2 from "@aws-cdk/aws-ec2";
 import * as cdk from "@aws-cdk/core";
+import * as iam from "@aws-cdk/aws-iam";
 import * as path from "path";
 import * as sns from "@aws-cdk/aws-sns";
 
@@ -49,11 +50,18 @@ describe("AuthenticatedApi", () => {
             method: apigatewayv2.HttpMethod.GET,
             lambdaProps: {
               entry: `${path.resolve(__dirname)}/routes/route1.js`,
-              handler: "route",
-              timeout: cdk.Duration.seconds(30),
               environment: {
                 TALIS_ENV_VAR: "some value",
               },
+              handler: "route",
+              policyStatements: [
+                new iam.PolicyStatement({
+                  effect: iam.Effect.ALLOW,
+                  actions: ['sqs:*'],
+                  resources: ['*'],
+                }),
+              ],
+              timeout: cdk.Duration.seconds(30),
             },
           },
           {

--- a/test/authenticated-api/authenticated-api.test.ts
+++ b/test/authenticated-api/authenticated-api.test.ts
@@ -57,8 +57,8 @@ describe("AuthenticatedApi", () => {
               policyStatements: [
                 new iam.PolicyStatement({
                   effect: iam.Effect.ALLOW,
-                  actions: ['sqs:*'],
-                  resources: ['*'],
+                  actions: ["sqs:*"],
+                  resources: ["*"],
                 }),
               ],
               timeout: cdk.Duration.seconds(30),

--- a/test/authenticated-api/authenticated-api.test.ts
+++ b/test/authenticated-api/authenticated-api.test.ts
@@ -157,7 +157,7 @@ describe("AuthenticatedApi", () => {
     test("provisions alarm to warn of latency on the api", () => {
       expectCDK(stack).to(
         haveResourceLike("AWS::CloudWatch::Alarm", {
-          AlarmName: "MyTestAuthenticatedApi-latency-alarm",
+          AlarmName: "test-MyTestAuthenticatedApi-latency-alarm",
           AlarmDescription:
             "Alarm if latency on api MyTestAuthenticatedApi exceeds 60000 milliseconds",
           Namespace: "AWS/ApiGateway",
@@ -183,7 +183,7 @@ describe("AuthenticatedApi", () => {
     test("provisions alarm to warn of latency on the api", () => {
       expectCDK(stack).to(
         haveResourceLike("AWS::CloudWatch::Alarm", {
-          AlarmName: "MyTestAuthenticatedApi-latency-alarm",
+          AlarmName: "test-MyTestAuthenticatedApi-latency-alarm",
           AlarmDescription:
             "Alarm if latency on api MyTestAuthenticatedApi exceeds 60000 milliseconds",
           Namespace: "AWS/ApiGateway",
@@ -209,7 +209,7 @@ describe("AuthenticatedApi", () => {
     test("provisions alarms on latency of lambda's", () => {
       expectCDK(stack).to(
         haveResourceLike("AWS::CloudWatch::Alarm", {
-          AlarmName: "MyTestAuthenticatedApi-route1-duration-alarm",
+          AlarmName: "test-MyTestAuthenticatedApi-route1-duration-alarm",
           AlarmDescription:
             "Alarm if duration of lambda for route MyTestAuthenticatedApi-route1 exceeds duration 60000 milliseconds",
           Namespace: "AWS/Lambda",
@@ -233,7 +233,7 @@ describe("AuthenticatedApi", () => {
 
       expectCDK(stack).to(
         haveResourceLike("AWS::CloudWatch::Alarm", {
-          AlarmName: "MyTestAuthenticatedApi-route2-duration-alarm",
+          AlarmName: "test-MyTestAuthenticatedApi-route2-duration-alarm",
           AlarmDescription:
             "Alarm if duration of lambda for route MyTestAuthenticatedApi-route2 exceeds duration 60000 milliseconds",
           Namespace: "AWS/Lambda",

--- a/test/lambda-worker/lambda-worker.test.ts
+++ b/test/lambda-worker/lambda-worker.test.ts
@@ -3,8 +3,9 @@ import {
   countResources,
   haveResourceLike,
 } from "@aws-cdk/assert";
-import * as ec2 from "@aws-cdk/aws-ec2";
 import * as cdk from "@aws-cdk/core";
+import * as ec2 from "@aws-cdk/aws-ec2";
+import * as iam from "@aws-cdk/aws-iam";
 import * as sns from "@aws-cdk/aws-sns";
 import { LambdaWorker } from "../../lib/lambda-worker";
 
@@ -30,6 +31,13 @@ describe("LambdaWorker", () => {
           entry: "examples/simple-lambda-worker/src/lambda/simple-worker.js",
           handler: "testWorker",
           memorySize: 2048,
+          policyStatements: [
+            new iam.PolicyStatement({
+              effect: iam.Effect.ALLOW,
+              actions: ['sqs:*'],
+              resources: ['*'],
+            }),
+          ],
           timeout: cdk.Duration.minutes(5),
           vpc: vpc,
           vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE },

--- a/test/lambda-worker/lambda-worker.test.ts
+++ b/test/lambda-worker/lambda-worker.test.ts
@@ -34,8 +34,8 @@ describe("LambdaWorker", () => {
           policyStatements: [
             new iam.PolicyStatement({
               effect: iam.Effect.ALLOW,
-              actions: ['sqs:*'],
-              resources: ['*'],
+              actions: ["sqs:*"],
+              resources: ["*"],
             }),
           ],
           timeout: cdk.Duration.minutes(5),
@@ -76,8 +76,8 @@ describe("LambdaWorker", () => {
       // We have a ticket to add integration tests for these constructs:
       // https://github.com/talis/platform/issues/5204
       // These will be tested in those integration tests.
-      expect(worker.lambdaQueueUrl).toBe('expected url');
-      expect(worker.lambdaQueueArn).toBe('expected arn');
+      expect(worker.lambdaQueueUrl).toBe("expected url");
+      expect(worker.lambdaQueueArn).toBe("expected arn");
     });
 
     test("provisions SQS queue and dead letter queue", () => {

--- a/test/lambda-worker/lambda-worker.test.ts
+++ b/test/lambda-worker/lambda-worker.test.ts
@@ -11,6 +11,7 @@ import { LambdaWorker } from "../../lib/lambda-worker";
 describe("LambdaWorker", () => {
   describe("with only required props", () => {
     let stack: cdk.Stack;
+    let worker: LambdaWorker;
 
     beforeAll(() => {
       const app = new cdk.App();
@@ -23,7 +24,7 @@ describe("LambdaWorker", () => {
         cidr: "10.0.0.0/16",
       });
 
-      new LambdaWorker(stack, "MyTestLambdaWorker", {
+      worker = new LambdaWorker(stack, "MyTestLambdaWorker", {
         name: "MyTestLambdaWorker",
         lambdaProps: {
           entry: "examples/simple-lambda-worker/src/lambda/simple-worker.js",
@@ -55,6 +56,20 @@ describe("LambdaWorker", () => {
           },
         })
       );
+    });
+
+    test.skip("exposes the sqs queue url and arn", () => {
+      // This test does not work. In this test suite the construct has been created,
+      // but the value of these properties are Tokens. e.g. "${Token[TOKEN.266]}"
+      // See: https://github.com/aws/aws-cdk/issues/7258
+      // And the reply it links to here: https://github.com/aws/aws-cdk/issues/7079#issuecomment-606394303
+      // The tokens are not resolved into URL's until the `prepare` phase
+      // This has not happened due to the way we are unit testing the constructs here.
+      // We have a ticket to add integration tests for these constructs:
+      // https://github.com/talis/platform/issues/5204
+      // These will be tested in those integration tests.
+      expect(worker.lambdaQueueUrl).toBe('expected url');
+      expect(worker.lambdaQueueArn).toBe('expected arn');
     });
 
     test("provisions SQS queue and dead letter queue", () => {


### PR DESCRIPTION
https://github.com/talis/platform/issues/5074

This PR makes changes to the `authenticated-api` construct and `lambda-worker` construct now that we are trying to use them outside of the examples within the project.