### PR TITLE
fix: require docker command to be passed to lambda

### DIFF
--- a/examples/container-lambda-worker/lib/container-lambda-worker-stack.ts
+++ b/examples/container-lambda-worker/lib/container-lambda-worker-stack.ts
@@ -82,6 +82,7 @@ export class ContainerLambdaWorkerStack extends cdk.Stack {
           environment: {
             EXAMPLE_ENV_VAR: "example value",
           },
+          dockerCommand: "container-worker.containerLambdaWorker",
           dockerImageTag: imageTag,
           ecrRepositoryArn: repository.repositoryArn,
           ecrRepositoryName: repository.repositoryName,

--- a/lib/lambda-worker/lambda-worker-props.ts
+++ b/lib/lambda-worker/lambda-worker-props.ts
@@ -11,6 +11,7 @@ export interface LambdaWorkerProps {
   // Documented here https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-lambda-nodejs.NodejsFunctionProps.html
   lambdaProps: {
     description?: string;
+    dockerCommand?: string;
     dockerImageTag?: string;
     ecrRepositoryArn?: string;
     ecrRepositoryName?: string;

--- a/lib/lambda-worker/lambda-worker.ts
+++ b/lib/lambda-worker/lambda-worker.ts
@@ -210,6 +210,7 @@ export class LambdaWorker extends cdk.Construct {
   isContainerLambda(props: LambdaWorkerProps): boolean {
     if (
       props.lambdaProps.dockerImageTag &&
+      props.lambdaProps.dockerCommand &&
       props.lambdaProps.ecrRepositoryArn &&
       props.lambdaProps.ecrRepositoryName &&
       !props.lambdaProps.entry &&
@@ -222,6 +223,7 @@ export class LambdaWorker extends cdk.Construct {
 
   isFunctionLambda(props: LambdaWorkerProps): boolean {
     if (
+      !props.lambdaProps.dockerCommand &&
       !props.lambdaProps.dockerImageTag &&
       !props.lambdaProps.ecrRepositoryArn &&
       !props.lambdaProps.ecrRepositoryName &&
@@ -292,6 +294,7 @@ export class LambdaWorker extends cdk.Construct {
     return new lambda.DockerImageFunction(this, props.name, {
       code: lambda.DockerImageCode.fromEcr(ecrRepository, {
         tag: imageTag,
+        cmd: [props.lambdaProps.dockerCommand ?? ""],
       }),
       functionName: props.name,
       description: props.lambdaProps.description,

--- a/test/lambda-worker/lambda-worker.test.ts
+++ b/test/lambda-worker/lambda-worker.test.ts
@@ -338,6 +338,7 @@ describe("LambdaWorker", () => {
             dockerImageTag: "test-lambda-12345",
             ecrRepositoryArn: "arn:aws:ecr:eu-west-1:012345678910:repository",
             ecrRepositoryName: "repository",
+            dockerCommand: "./src/script",
             memorySize: 2048,
             policyStatements: [
               new iam.PolicyStatement({
@@ -581,6 +582,7 @@ describe("LambdaWorker", () => {
     const cases = [
       {
         description: "throws an exception when all are specified",
+        dockerCommand: "./src/example",
         dockerImageTag: "test-image-12345",
         ecrRepositoryArn: "arn:aws:ecr:eu-west-1:012345678910:repository/test",
         ecrRepositoryName: "repository",
@@ -589,6 +591,7 @@ describe("LambdaWorker", () => {
       },
       {
         description: "throws an exception when none are specified",
+        dockerCommand: undefined,
         dockerImageTag: undefined,
         ecrRepositoryArn: undefined,
         ecrRepositoryName: undefined,
@@ -597,6 +600,7 @@ describe("LambdaWorker", () => {
       },
       {
         description: "throws an exception when only handler is specified",
+        dockerCommand: undefined,
         dockerImageTag: undefined,
         ecrRepositoryArn: undefined,
         ecrRepositoryName: undefined,
@@ -605,6 +609,7 @@ describe("LambdaWorker", () => {
       },
       {
         description: "throws an exception when only entry is specified",
+        dockerCommand: undefined,
         dockerImageTag: undefined,
         ecrRepositoryArn: undefined,
         ecrRepositoryName: undefined,
@@ -614,6 +619,7 @@ describe("LambdaWorker", () => {
       {
         description:
           "throws an exception when only dockerImageTag is specified",
+        dockerCommand: undefined,
         dockerImageTag: "test-lambda-12345",
         ecrRepositoryArn: undefined,
         ecrRepositoryName: undefined,
@@ -623,6 +629,7 @@ describe("LambdaWorker", () => {
       {
         description:
           "throws an exception when only ecrRepositoryArn is specified",
+        dockerCommand: undefined,
         dockerImageTag: undefined,
         ecrRepositoryArn: "arn:aws:ecr:eu-west-1:012345678910:repository/test",
         handler: undefined,
@@ -631,9 +638,19 @@ describe("LambdaWorker", () => {
       {
         description:
           "throws an exception when only ecrRepositoryName is specified",
+        dockerCommand: undefined,
         dockerImageTag: undefined,
         ecrRepositoryArn: undefined,
         ecrRepositoryName: "repository",
+        handler: undefined,
+        entry: undefined,
+      },
+      {
+        description: "throws an exception when only dockerCommand is specified",
+        dockerCommand: "src/example",
+        dockerImageTag: undefined,
+        ecrRepositoryArn: undefined,
+        ecrRepositoryName: undefined,
         handler: undefined,
         entry: undefined,
       },
@@ -657,8 +674,10 @@ describe("LambdaWorker", () => {
             lambdaProps: {
               entry: config.entry,
               handler: config.handler,
+              dockerCommand: config.dockerCommand,
               dockerImageTag: config.dockerImageTag,
               ecrRepositoryArn: config.ecrRepositoryArn,
+              ecrRepositoryName: config.ecrRepositoryName,
               memorySize: 2048,
               timeout: cdk.Duration.minutes(5),
               vpc: vpc,


### PR DESCRIPTION
When creating a container lambda worker the entrypoint to the container needs to be specified as the command to run when starting the docker container.

This change makes this a required property when creating a container lambda worker.