### PR TITLE
feat: expose enable queue prop for disabling of queue worker

### DIFF
--- a/lib/lambda-worker/lambda-worker-props.ts
+++ b/lib/lambda-worker/lambda-worker-props.ts
@@ -18,6 +18,7 @@ export interface LambdaWorkerProps {
     ecrRepositoryName?: string;
     handler?: string;
     entry?: string;
+    enableQueue?: boolean;
     environment?: { [key: string]: string };
     filesystem?: lambda.FileSystem;
     memorySize: number; // LambdaWorker will set a minimum memory size of 1024

--- a/lib/lambda-worker/lambda-worker.ts
+++ b/lib/lambda-worker/lambda-worker.ts
@@ -116,7 +116,7 @@ export class LambdaWorker extends cdk.Construct {
     // By default, the main queue is enabled and the DLQ is disabled
     lambdaWorker.addEventSource(
       new eventSource.SqsEventSource(lambdaQueue, {
-        enabled: true,
+        enabled: props.lambdaProps.enableQueue ?? true,
         batchSize: 1,
       })
     );


### PR DESCRIPTION
Allow queue event source to be enabled or disabled on the queue worker. This is an optional property `enableQueue` that defaults to true if unset.