### PR TITLE
fix: main branch not master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,7 +150,7 @@ workflows:
           filters:
             branches:
               ignore:
-                - master
+                - main
                 - /^dependabot-.*$/
       - build:
           requires:


### PR DESCRIPTION
Issue: https://github.com/talis/platform/issues/5204

In https://github.com/talis/talis-cdk-constructs/pull/28 we added a `be_kind_to_your_colleagues` to the build. However, the repo this was copied and pasted from still uses `master` rather than `main`. This was not picked up in the copy/paste.

This has resulted in the `be_kind_to_your_colleagues` step running on the build after the merge to `main`.

This PR therefore renames `master` to `main` in the circle build.