### PR TITLE
fix: reduce build time by importing security group

### DIFF
--- a/examples/simple-authenticated-api/lib/simple-authenticated-api-stack.ts
+++ b/examples/simple-authenticated-api/lib/simple-authenticated-api-stack.ts
@@ -30,6 +30,21 @@ export class SimpleAuthenticatedApiStack extends cdk.Stack {
       vpcId: "vpc-0155db5e1ab5c28b6",
     });
 
+    // Setting a security group is an option. This is an example of importing and using a 
+    // pre existing security group. This one is defined in terraform.
+    // An ulterior motive for importing this security group is that without specifying
+    // one, the default group created will add significant time to deploy and destroy
+    // steps in the build. This is not a problem IRL where the group will only be created
+    // once instead of being created and destroyed on every build.
+    const lambdaSecurityGroup = ec2.SecurityGroup.fromSecurityGroupId(
+      this,
+      'talis-cdk-constructs-build',
+      'sg-0f2486a645df2533c',
+      {
+        mutable: false,
+      },
+    );
+
     /* const api = */ new AuthenticatedApi(this, "simple-authenticated-api", {
       prefix,
       name: "simple-authenticated-api",
@@ -38,6 +53,7 @@ export class SimpleAuthenticatedApiStack extends cdk.Stack {
       alarmTopic,
       vpc,
       vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_NAT },
+      securityGroup: lambdaSecurityGroup,
 
       persona: {
         host: "staging-users.talis.com",

--- a/examples/simple-authenticated-api/lib/simple-authenticated-api-stack.ts
+++ b/examples/simple-authenticated-api/lib/simple-authenticated-api-stack.ts
@@ -26,6 +26,10 @@ export class SimpleAuthenticatedApiStack extends cdk.Stack {
       { topicName: `${prefix}simple-authenticated-api-alarm` }
     );
 
+    const vpc = ec2.Vpc.fromLookup(this, `${prefix}-vpc`, {
+      vpcId: "vpc-0155db5e1ab5c28b6",
+    });
+
     // Setting a security group is an option. This is an example of importing and using a
     // pre existing security group. This one is defined in terraform.
     // An ulterior motive for importing this security group is that without specifying
@@ -40,10 +44,6 @@ export class SimpleAuthenticatedApiStack extends cdk.Stack {
         mutable: false,
       }
     );
-
-    const vpc = ec2.Vpc.fromLookup(this, `${prefix}-vpc`, {
-      vpcId: "vpc-0155db5e1ab5c28b6",
-    });
 
     /* const api = */ new AuthenticatedApi(this, "simple-authenticated-api", {
       prefix,

--- a/examples/simple-authenticated-api/lib/simple-authenticated-api-stack.ts
+++ b/examples/simple-authenticated-api/lib/simple-authenticated-api-stack.ts
@@ -30,7 +30,7 @@ export class SimpleAuthenticatedApiStack extends cdk.Stack {
       vpcId: "vpc-0155db5e1ab5c28b6",
     });
 
-    // Setting a security group is an option. This is an example of importing and using a 
+    // Setting a security group is an option. This is an example of importing and using a
     // pre existing security group. This one is defined in terraform.
     // An ulterior motive for importing this security group is that without specifying
     // one, the default group created will add significant time to deploy and destroy
@@ -38,11 +38,11 @@ export class SimpleAuthenticatedApiStack extends cdk.Stack {
     // once instead of being created and destroyed on every build.
     const lambdaSecurityGroup = ec2.SecurityGroup.fromSecurityGroupId(
       this,
-      'talis-cdk-constructs-build',
-      'sg-0f2486a645df2533c',
+      "talis-cdk-constructs-build",
+      "sg-0f2486a645df2533c",
       {
         mutable: false,
-      },
+      }
     );
 
     /* const api = */ new AuthenticatedApi(this, "simple-authenticated-api", {

--- a/examples/simple-authenticated-api/lib/simple-authenticated-api-stack.ts
+++ b/examples/simple-authenticated-api/lib/simple-authenticated-api-stack.ts
@@ -38,8 +38,8 @@ export class SimpleAuthenticatedApiStack extends cdk.Stack {
     // once instead of being created and destroyed on every build.
     const lambdaSecurityGroup = ec2.SecurityGroup.fromSecurityGroupId(
       this,
-      "depot-serverless-lambda-security-group",
-      "sg-002cdd87d0c5a0fb0",
+      "talis-cdk-constructs-build",
+      "sg-091ff6e1188944bb5",
       {
         mutable: false,
       }

--- a/examples/simple-authenticated-api/lib/simple-authenticated-api-stack.ts
+++ b/examples/simple-authenticated-api/lib/simple-authenticated-api-stack.ts
@@ -38,8 +38,8 @@ export class SimpleAuthenticatedApiStack extends cdk.Stack {
     // once instead of being created and destroyed on every build.
     const lambdaSecurityGroup = ec2.SecurityGroup.fromSecurityGroupId(
       this,
-      "talis-cdk-constructs-build",
-      "sg-091ff6e1188944bb5",
+      "depot-serverless-lambda-security-group",
+      "sg-002cdd87d0c5a0fb0",
       {
         mutable: false,
       }

--- a/examples/simple-authenticated-api/lib/simple-authenticated-api-stack.ts
+++ b/examples/simple-authenticated-api/lib/simple-authenticated-api-stack.ts
@@ -26,10 +26,6 @@ export class SimpleAuthenticatedApiStack extends cdk.Stack {
       { topicName: `${prefix}simple-authenticated-api-alarm` }
     );
 
-    const vpc = ec2.Vpc.fromLookup(this, `${prefix}-vpc`, {
-      vpcId: "vpc-0155db5e1ab5c28b6",
-    });
-
     // Setting a security group is an option. This is an example of importing and using a
     // pre existing security group. This one is defined in terraform.
     // An ulterior motive for importing this security group is that without specifying
@@ -44,6 +40,10 @@ export class SimpleAuthenticatedApiStack extends cdk.Stack {
         mutable: false,
       }
     );
+
+    const vpc = ec2.Vpc.fromLookup(this, `${prefix}-vpc`, {
+      vpcId: "vpc-0155db5e1ab5c28b6",
+    });
 
     /* const api = */ new AuthenticatedApi(this, "simple-authenticated-api", {
       prefix,

--- a/examples/simple-authenticated-api/lib/simple-authenticated-api-stack.ts
+++ b/examples/simple-authenticated-api/lib/simple-authenticated-api-stack.ts
@@ -39,7 +39,7 @@ export class SimpleAuthenticatedApiStack extends cdk.Stack {
     const lambdaSecurityGroup = ec2.SecurityGroup.fromSecurityGroupId(
       this,
       "talis-cdk-constructs-build",
-      "sg-0f2486a645df2533c",
+      "sg-091ff6e1188944bb5",
       {
         mutable: false,
       }

--- a/examples/simple-lambda-worker/lib/simple-lambda-worker-stack.ts
+++ b/examples/simple-lambda-worker/lib/simple-lambda-worker-stack.ts
@@ -41,7 +41,7 @@ export class SimpleLambdaWorkerStack extends cdk.Stack {
       vpcId: "vpc-0155db5e1ab5c28b6",
     });
 
-    // Setting a security group is an option. This is an example of importing and using a 
+    // Setting a security group is an option. This is an example of importing and using a
     // pre existing security group. This one is defined in terraform.
     // An ulterior motive for importing this security group is that without specifying
     // one, the default group created will add significant time to deploy and destroy
@@ -49,11 +49,11 @@ export class SimpleLambdaWorkerStack extends cdk.Stack {
     // once instead of being created and destroyed on every build.
     const lambdaSecurityGroup = ec2.SecurityGroup.fromSecurityGroupId(
       this,
-      'talis-cdk-constructs-build',
-      'sg-0f2486a645df2533c',
+      "talis-cdk-constructs-build",
+      "sg-0f2486a645df2533c",
       {
         mutable: false,
-      },
+      }
     );
 
     // In this example, and to aid integration tests, after successfully processing

--- a/examples/simple-lambda-worker/lib/simple-lambda-worker-stack.ts
+++ b/examples/simple-lambda-worker/lib/simple-lambda-worker-stack.ts
@@ -41,6 +41,21 @@ export class SimpleLambdaWorkerStack extends cdk.Stack {
       vpcId: "vpc-0155db5e1ab5c28b6",
     });
 
+    // Setting a security group is an option. This is an example of importing and using a 
+    // pre existing security group. This one is defined in terraform.
+    // An ulterior motive for importing this security group is that without specifying
+    // one, the default group created will add significant time to deploy and destroy
+    // steps in the build. This is not a problem IRL where the group will only be created
+    // once instead of being created and destroyed on every build.
+    const lambdaSecurityGroup = ec2.SecurityGroup.fromSecurityGroupId(
+      this,
+      'talis-cdk-constructs-build',
+      'sg-0f2486a645df2533c',
+      {
+        mutable: false,
+      },
+    );
+
     // In this example, and to aid integration tests, after successfully processing
     // a message the lambda worker will send a new messages to an SQS queue.
     // This is a common thing for the worker to do - passing to the next
@@ -64,6 +79,7 @@ export class SimpleLambdaWorkerStack extends cdk.Stack {
           entry: "src/lambda/simple-worker.js",
           handler: "simpleLambdaWorker",
           memorySize: 1024,
+          securityGroup: lambdaSecurityGroup,
           timeout: cdk.Duration.seconds(30),
           vpc: vpc,
           vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_NAT },

--- a/examples/simple-lambda-worker/lib/simple-lambda-worker-stack.ts
+++ b/examples/simple-lambda-worker/lib/simple-lambda-worker-stack.ts
@@ -49,8 +49,8 @@ export class SimpleLambdaWorkerStack extends cdk.Stack {
     // once instead of being created and destroyed on every build.
     const lambdaSecurityGroup = ec2.SecurityGroup.fromSecurityGroupId(
       this,
-      "depot-serverless-lambda-security-group",
-      "sg-002cdd87d0c5a0fb0",
+      "talis-cdk-constructs-build",
+      "sg-091ff6e1188944bb5",
       {
         mutable: false,
       }

--- a/examples/simple-lambda-worker/lib/simple-lambda-worker-stack.ts
+++ b/examples/simple-lambda-worker/lib/simple-lambda-worker-stack.ts
@@ -50,7 +50,7 @@ export class SimpleLambdaWorkerStack extends cdk.Stack {
     const lambdaSecurityGroup = ec2.SecurityGroup.fromSecurityGroupId(
       this,
       "talis-cdk-constructs-build",
-      "sg-0f2486a645df2533c",
+      "sg-091ff6e1188944bb5",
       {
         mutable: false,
       }

--- a/examples/simple-lambda-worker/lib/simple-lambda-worker-stack.ts
+++ b/examples/simple-lambda-worker/lib/simple-lambda-worker-stack.ts
@@ -49,8 +49,8 @@ export class SimpleLambdaWorkerStack extends cdk.Stack {
     // once instead of being created and destroyed on every build.
     const lambdaSecurityGroup = ec2.SecurityGroup.fromSecurityGroupId(
       this,
-      "talis-cdk-constructs-build",
-      "sg-091ff6e1188944bb5",
+      "depot-serverless-lambda-security-group",
+      "sg-002cdd87d0c5a0fb0",
       {
         mutable: false,
       }

--- a/lib/authenticated-api/authenticated-api.ts
+++ b/lib/authenticated-api/authenticated-api.ts
@@ -110,6 +110,10 @@ export class AuthenticatedApi extends cdk.Construct {
           vpcSubnets: props.vpcSubnets,
         }
       );
+      routeLambda.node.addDependency(authLambda);
+      /* authLambda.node.addDependency(routeLambda);
+      /* authorizer.node.addDependency(routeLambda); */ // Not valid
+      /* routeLambda.node.addDependency(authorizer); */ // does not implement DependableTrait
 
       if (routeProps.lambdaProps.policyStatements) {
         for (const statement of routeProps.lambdaProps.policyStatements) {

--- a/lib/authenticated-api/authenticated-api.ts
+++ b/lib/authenticated-api/authenticated-api.ts
@@ -110,10 +110,6 @@ export class AuthenticatedApi extends cdk.Construct {
           vpcSubnets: props.vpcSubnets,
         }
       );
-      routeLambda.node.addDependency(authLambda);
-      /* authLambda.node.addDependency(routeLambda);
-      /* authorizer.node.addDependency(routeLambda); */ // Not valid
-      /* routeLambda.node.addDependency(authorizer); */ // does not implement DependableTrait
 
       if (routeProps.lambdaProps.policyStatements) {
         for (const statement of routeProps.lambdaProps.policyStatements) {


### PR DESCRIPTION
https://github.com/talis/platform/issues/5272

The destroy stacks steps in the build are taking 20 minutes plus. This is due to the creation and destruction of a security group.

This PR changes the example stacks deployed in the build to use an imported security group - therefore significantly reducing build times.

Note: This PR only fixes the first issue with the length of the build. Having fixed this, the tear down of the simple lambda worker stack is much reduced. However, we have another problem with the authenticated api construct which we are still  investigating.