### PR TITLE
fix: change reference for talis node package

### DIFF
--- a/examples/simple-authenticated-api/package-lock.json
+++ b/examples/simple-authenticated-api/package-lock.json
@@ -1142,9 +1142,9 @@
       "dev": true
     },
     "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -5799,9 +5799,9 @@
       "dev": true
     },
     "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -5843,13 +5843,13 @@
       }
     },
     "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
       }
     },
@@ -6475,9 +6475,9 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
     },
     "react-is": {
       "version": "17.0.2",
@@ -7132,9 +7132,9 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -7293,8 +7293,8 @@
       }
     },
     "talis-node": {
-      "version": "git://github.com/talis/talis-node.git#55fa339a6958236f30a8701a7dee510f2724c6c3",
-      "from": "git://github.com/talis/talis-node.git#v0.0.3",
+      "version": "git+https://github.com/talis/talis-node.git#55fa339a6958236f30a8701a7dee510f2724c6c3",
+      "from": "git+https://github.com/talis/talis-node.git#v0.0.3",
       "requires": {
         "cache-service": "1.3.5",
         "cache-service-node-cache": "2.0.0",

--- a/examples/simple-authenticated-api/package.json
+++ b/examples/simple-authenticated-api/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@aws-cdk/core": "1.129.0",
-    "talis-node": "git://github.com/talis/talis-node.git#v0.0.3",
+    "talis-node": "https://github.com/talis/talis-node.git#v0.0.3",
     "source-map-support": "^0.5.16"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10319,8 +10319,8 @@
       }
     },
     "talis-node": {
-      "version": "git://github.com/talis/talis-node.git#55fa339a6958236f30a8701a7dee510f2724c6c3",
-      "from": "git://github.com/talis/talis-node.git#v0.0.3",
+      "version": "git+https://github.com/talis/talis-node.git#55fa339a6958236f30a8701a7dee510f2724c6c3",
+      "from": "git+https://github.com/talis/talis-node.git#v0.0.3",
       "requires": {
         "cache-service": "1.3.5",
         "cache-service-node-cache": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@aws-cdk/aws-sqs": "1.129.0",
     "@aws-cdk/core": "1.129.0",
     "cdk-ecr-deployment": "0.0.80",
-    "talis-node": "git://github.com/talis/talis-node.git#v0.0.3",
+    "talis-node": "https://github.com/talis/talis-node.git#v0.0.3",
     "uuid": "8.3.2"
   }
 }


### PR DESCRIPTION
Changes the package reference for talis node to use `https` protocol over `git` protocol due to brownout caused by https://github.blog/2021-09-01-improving-git-protocol-security-github/