### PR TITLE
feat: refactor cfn prefixers and add lambda prefixer

### DIFF
--- a/lib/aspects/resource_prefixer/cfn_resource_prefixer.ts
+++ b/lib/aspects/resource_prefixer/cfn_resource_prefixer.ts
@@ -1,4 +1,4 @@
-import { IConstruct } from "@aws-cdk/core";
+import { IConstruct, CfnResource, Token } from "@aws-cdk/core";
 
 export interface CfnResourcePrefixer {
   prefix(): void;
@@ -6,4 +6,39 @@ export interface CfnResourcePrefixer {
 
 export interface CfnResourcePrefixerConstructor {
   new (node: IConstruct, resourcePrefix: string): CfnResourcePrefixer;
+}
+
+export abstract class CfnResourcePrefixerBase implements CfnResourcePrefixer {
+  protected node: CfnResource;
+  protected resourcePrefix: string;
+
+  constructor(node: IConstruct, resourcePrefix: string) {
+    if (!CfnResource.isCfnResource(node)) {
+      throw new Error("Node is not a CfnResource");
+    }
+    this.node = node;
+    this.resourcePrefix = resourcePrefix;
+  }
+
+  protected prefixResourceName(
+    name: string | undefined,
+    propertyPath: string
+  ): void {
+    if (!Token.isUnresolved(name)) {
+      this.node.addPropertyOverride(
+        propertyPath,
+        `${this.resourcePrefix}${name}`
+      );
+    } else {
+      const logicalId = this.node.stack.getLogicalId(this.node);
+      this.node.addPropertyOverride(
+        propertyPath,
+        `${this.resourcePrefix}${logicalId}`
+      );
+    }
+  }
+
+  public prefix() {
+    throw new Error("Not implemented");
+  }
 }

--- a/lib/aspects/resource_prefixer/prefixers/apigatewayv2_cfn_api_prefixer.ts
+++ b/lib/aspects/resource_prefixer/prefixers/apigatewayv2_cfn_api_prefixer.ts
@@ -1,25 +1,25 @@
 import { CfnApi } from "@aws-cdk/aws-apigatewayv2";
 import { IConstruct } from "@aws-cdk/core";
-import { CfnResourcePrefixer } from "../cfn_resource_prefixer";
+import {
+  CfnResourcePrefixer,
+  CfnResourcePrefixerBase,
+} from "../cfn_resource_prefixer";
 
-export class Apigatewayv2CfnApiPrefixer implements CfnResourcePrefixer {
-  private node: CfnApi;
-  private resourcePrefix: string;
-
+export class Apigatewayv2CfnApiPrefixer
+  extends CfnResourcePrefixerBase
+  implements CfnResourcePrefixer
+{
   constructor(node: IConstruct, resourcePrefix: string) {
     if (!(node instanceof CfnApi)) {
       throw new Error(
         "Specified node is not an instance of CfnApi and cannot be prefixed using this prefixer"
       );
     }
-    this.node = node;
-    this.resourcePrefix = resourcePrefix;
+    super(node, resourcePrefix);
   }
 
   public prefix(): void {
-    this.node.addPropertyOverride(
-      "Name",
-      `${this.resourcePrefix}${this.node.name}`
-    );
+    const api = this.node as CfnApi;
+    this.prefixResourceName(api.name, "Name");
   }
 }

--- a/lib/aspects/resource_prefixer/prefixers/apigatewayv2_cfn_stage_prefixer.ts
+++ b/lib/aspects/resource_prefixer/prefixers/apigatewayv2_cfn_stage_prefixer.ts
@@ -1,19 +1,21 @@
 import { CfnStage } from "@aws-cdk/aws-apigatewayv2";
 import { IConstruct } from "@aws-cdk/core";
-import { CfnResourcePrefixer } from "../cfn_resource_prefixer";
+import {
+  CfnResourcePrefixer,
+  CfnResourcePrefixerBase,
+} from "../cfn_resource_prefixer";
 
-export class Apigatewayv2CfnStagePrefixer implements CfnResourcePrefixer {
-  private node: CfnStage;
-  private resourcePrefix: string;
-
+export class Apigatewayv2CfnStagePrefixer
+  extends CfnResourcePrefixerBase
+  implements CfnResourcePrefixer
+{
   constructor(node: IConstruct, resourcePrefix: string) {
     if (!(node instanceof CfnStage)) {
       throw new Error(
         "Specified node is not an instance of CfnStage and cannot be prefixed using this prefixer"
       );
     }
-    this.node = node;
-    this.resourcePrefix = resourcePrefix;
+    super(node, resourcePrefix);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/lib/aspects/resource_prefixer/prefixers/dynamodb_cfn_table_prefixer.ts
+++ b/lib/aspects/resource_prefixer/prefixers/dynamodb_cfn_table_prefixer.ts
@@ -1,25 +1,25 @@
 import { CfnTable } from "@aws-cdk/aws-dynamodb";
 import { IConstruct } from "@aws-cdk/core";
-import { CfnResourcePrefixer } from "../cfn_resource_prefixer";
+import {
+  CfnResourcePrefixer,
+  CfnResourcePrefixerBase,
+} from "../cfn_resource_prefixer";
 
-export class DynamoDbCfnTablePrefixer implements CfnResourcePrefixer {
-  private node: CfnTable;
-  private resourcePrefix: string;
-
+export class DynamoDbCfnTablePrefixer
+  extends CfnResourcePrefixerBase
+  implements CfnResourcePrefixer
+{
   constructor(node: IConstruct, resourcePrefix: string) {
     if (!(node instanceof CfnTable)) {
       throw new Error(
         "Specified node is not an instance of CfnTable and cannot be prefixed using this prefixer"
       );
     }
-    this.node = node;
-    this.resourcePrefix = resourcePrefix;
+    super(node, resourcePrefix);
   }
 
   public prefix(): void {
-    this.node.addPropertyOverride(
-      "TableName",
-      `${this.resourcePrefix}${this.node.tableName}`
-    );
+    const table = this.node as CfnTable;
+    this.prefixResourceName(table.tableName, "TableName");
   }
 }

--- a/lib/aspects/resource_prefixer/prefixers/ec2_cfn_security_group_prefixer.ts
+++ b/lib/aspects/resource_prefixer/prefixers/ec2_cfn_security_group_prefixer.ts
@@ -1,0 +1,25 @@
+import { CfnSecurityGroup } from "@aws-cdk/aws-ec2";
+import { IConstruct } from "@aws-cdk/core";
+import {
+  CfnResourcePrefixer,
+  CfnResourcePrefixerBase,
+} from "../cfn_resource_prefixer";
+
+export class Ec2CfnSecurityGroupPrefixer
+  extends CfnResourcePrefixerBase
+  implements CfnResourcePrefixer
+{
+  constructor(node: IConstruct, resourcePrefix: string) {
+    if (!(node instanceof CfnSecurityGroup)) {
+      throw new Error(
+        "Specified node is not an instance of CfnSecurityGroup and cannot be prefixed using this prefixer"
+      );
+    }
+    super(node, resourcePrefix);
+  }
+
+  public prefix(): void {
+    const securityGroup = this.node as CfnSecurityGroup;
+    this.prefixResourceName(securityGroup.groupName, "GroupName");
+  }
+}

--- a/lib/aspects/resource_prefixer/prefixers/iam_cfn_role_prefixer.ts
+++ b/lib/aspects/resource_prefixer/prefixers/iam_cfn_role_prefixer.ts
@@ -1,0 +1,25 @@
+import { CfnRole } from "@aws-cdk/aws-iam";
+import { IConstruct } from "@aws-cdk/core";
+import {
+  CfnResourcePrefixer,
+  CfnResourcePrefixerBase,
+} from "../cfn_resource_prefixer";
+
+export class IamCfnRolePrefixer
+  extends CfnResourcePrefixerBase
+  implements CfnResourcePrefixer
+{
+  constructor(node: IConstruct, resourcePrefix: string) {
+    if (!(node instanceof CfnRole)) {
+      throw new Error(
+        "Specified node is not an instance of CfnRole and cannot be prefixed using this prefixer"
+      );
+    }
+    super(node, resourcePrefix);
+  }
+
+  public prefix(): void {
+    const role = this.node as CfnRole;
+    this.prefixResourceName(role.roleName, "RoleName");
+  }
+}

--- a/lib/aspects/resource_prefixer/prefixers/index.ts
+++ b/lib/aspects/resource_prefixer/prefixers/index.ts
@@ -3,3 +3,4 @@ export * from "./apigatewayv2_cfn_stage_prefixer";
 export * from "./dynamodb_cfn_table_prefixer";
 export * from "./ec2_cfn_security_group_prefixer";
 export * from "./iam_cfn_role_prefixer";
+export * from "./lambda_cfn_function_prefixer";

--- a/lib/aspects/resource_prefixer/prefixers/index.ts
+++ b/lib/aspects/resource_prefixer/prefixers/index.ts
@@ -2,3 +2,4 @@ export * from "./apigatewayv2_cfn_api_prefixer";
 export * from "./apigatewayv2_cfn_stage_prefixer";
 export * from "./dynamodb_cfn_table_prefixer";
 export * from "./ec2_cfn_security_group_prefixer";
+export * from "./iam_cfn_role_prefixer";

--- a/lib/aspects/resource_prefixer/prefixers/index.ts
+++ b/lib/aspects/resource_prefixer/prefixers/index.ts
@@ -1,3 +1,4 @@
 export * from "./apigatewayv2_cfn_api_prefixer";
 export * from "./apigatewayv2_cfn_stage_prefixer";
 export * from "./dynamodb_cfn_table_prefixer";
+export * from "./ec2_cfn_security_group_prefixer";

--- a/lib/aspects/resource_prefixer/prefixers/lambda_cfn_function_prefixer.ts
+++ b/lib/aspects/resource_prefixer/prefixers/lambda_cfn_function_prefixer.ts
@@ -1,0 +1,25 @@
+import { CfnFunction } from "@aws-cdk/aws-lambda";
+import { IConstruct } from "@aws-cdk/core";
+import {
+  CfnResourcePrefixer,
+  CfnResourcePrefixerBase,
+} from "../cfn_resource_prefixer";
+
+export class LambdaCfnFunctionPrefixer
+  extends CfnResourcePrefixerBase
+  implements CfnResourcePrefixer
+{
+  constructor(node: IConstruct, resourcePrefix: string) {
+    if (!(node instanceof CfnFunction)) {
+      throw new Error(
+        "Specified node is not an instance of CfnFunction and cannot be prefixed using this prefixer"
+      );
+    }
+    super(node, resourcePrefix);
+  }
+
+  public prefix(): void {
+    const lambda = this.node as CfnFunction;
+    this.prefixResourceName(lambda.functionName, "FunctionName");
+  }
+}

--- a/lib/aspects/resource_prefixer/resource_prefixer.ts
+++ b/lib/aspects/resource_prefixer/resource_prefixer.ts
@@ -54,7 +54,7 @@ export class ResourcePrefixer implements IAspect {
       }
     }
 
-    throw new Error("Undefined resource for resource prefixer");
+    throw new Error(`Undefined resource for resource prefixer: ${node.cfnResourceType}`);
   }
 
   private registerPrefixer(

--- a/lib/aspects/resource_prefixer/resource_prefixer.ts
+++ b/lib/aspects/resource_prefixer/resource_prefixer.ts
@@ -5,12 +5,14 @@ import {
   DynamoDbCfnTablePrefixer,
   Ec2CfnSecurityGroupPrefixer,
   IamCfnRolePrefixer,
+  LambdaCfnFunctionPrefixer,
 } from "./prefixers";
 import { CfnResourcePrefixer } from "./cfn_resource_prefixer";
 import { CfnTable } from "@aws-cdk/aws-dynamodb";
 import { CfnApi, CfnStage } from "@aws-cdk/aws-apigatewayv2";
 import { CfnSecurityGroup } from "@aws-cdk/aws-ec2";
 import { CfnRole } from "@aws-cdk/aws-iam";
+import { CfnFunction } from "@aws-cdk/aws-lambda";
 
 export type Constructor<T> = { new (...args: any[]): T };
 
@@ -33,6 +35,7 @@ export class ResourcePrefixer implements IAspect {
     this.registerPrefixer(CfnStage, Apigatewayv2CfnStagePrefixer);
     this.registerPrefixer(CfnSecurityGroup, Ec2CfnSecurityGroupPrefixer);
     this.registerPrefixer(CfnRole, IamCfnRolePrefixer);
+    this.registerPrefixer(CfnFunction, LambdaCfnFunctionPrefixer);
   }
 
   public visit(node: IConstruct): void {

--- a/lib/aspects/resource_prefixer/resource_prefixer.ts
+++ b/lib/aspects/resource_prefixer/resource_prefixer.ts
@@ -54,7 +54,9 @@ export class ResourcePrefixer implements IAspect {
       }
     }
 
-    throw new Error(`Undefined resource for resource prefixer: ${node.cfnResourceType}`);
+    throw new Error(
+      `Undefined resource for resource prefixer: ${node.cfnResourceType}`
+    );
   }
 
   private registerPrefixer(

--- a/lib/aspects/resource_prefixer/resource_prefixer.ts
+++ b/lib/aspects/resource_prefixer/resource_prefixer.ts
@@ -4,11 +4,13 @@ import {
   Apigatewayv2CfnStagePrefixer,
   DynamoDbCfnTablePrefixer,
   Ec2CfnSecurityGroupPrefixer,
+  IamCfnRolePrefixer,
 } from "./prefixers";
 import { CfnResourcePrefixer } from "./cfn_resource_prefixer";
 import { CfnTable } from "@aws-cdk/aws-dynamodb";
 import { CfnApi, CfnStage } from "@aws-cdk/aws-apigatewayv2";
 import { CfnSecurityGroup } from "@aws-cdk/aws-ec2";
+import { CfnRole } from "@aws-cdk/aws-iam";
 
 export type Constructor<T> = { new (...args: any[]): T };
 
@@ -30,6 +32,7 @@ export class ResourcePrefixer implements IAspect {
     this.registerPrefixer(CfnApi, Apigatewayv2CfnApiPrefixer);
     this.registerPrefixer(CfnStage, Apigatewayv2CfnStagePrefixer);
     this.registerPrefixer(CfnSecurityGroup, Ec2CfnSecurityGroupPrefixer);
+    this.registerPrefixer(CfnRole, IamCfnRolePrefixer);
   }
 
   public visit(node: IConstruct): void {

--- a/lib/aspects/resource_prefixer/resource_prefixer.ts
+++ b/lib/aspects/resource_prefixer/resource_prefixer.ts
@@ -3,10 +3,12 @@ import {
   Apigatewayv2CfnApiPrefixer,
   Apigatewayv2CfnStagePrefixer,
   DynamoDbCfnTablePrefixer,
+  Ec2CfnSecurityGroupPrefixer,
 } from "./prefixers";
 import { CfnResourcePrefixer } from "./cfn_resource_prefixer";
 import { CfnTable } from "@aws-cdk/aws-dynamodb";
 import { CfnApi, CfnStage } from "@aws-cdk/aws-apigatewayv2";
+import { CfnSecurityGroup } from "@aws-cdk/aws-ec2";
 
 export type Constructor<T> = { new (...args: any[]): T };
 
@@ -27,6 +29,7 @@ export class ResourcePrefixer implements IAspect {
     this.registerPrefixer(CfnTable, DynamoDbCfnTablePrefixer);
     this.registerPrefixer(CfnApi, Apigatewayv2CfnApiPrefixer);
     this.registerPrefixer(CfnStage, Apigatewayv2CfnStagePrefixer);
+    this.registerPrefixer(CfnSecurityGroup, Ec2CfnSecurityGroupPrefixer);
   }
 
   public visit(node: IConstruct): void {

--- a/test/fixtures/infra/aws-ec2/cfn_security_group.ts
+++ b/test/fixtures/infra/aws-ec2/cfn_security_group.ts
@@ -1,0 +1,45 @@
+import { CfnSecurityGroupProps } from "@aws-cdk/aws-ec2";
+
+export const CfnSecurityGroupProperties: CfnSecurityGroupProps = {
+  groupDescription: "groupDescription",
+
+  // the properties below are optional
+  groupName: "groupName",
+  securityGroupEgress: [
+    {
+      ipProtocol: "ipProtocol",
+
+      // the properties below are optional
+      cidrIp: "cidrIp",
+      cidrIpv6: "cidrIpv6",
+      description: "description",
+      destinationPrefixListId: "destinationPrefixListId",
+      destinationSecurityGroupId: "destinationSecurityGroupId",
+      fromPort: 123,
+      toPort: 123,
+    },
+  ],
+  securityGroupIngress: [
+    {
+      ipProtocol: "ipProtocol",
+
+      // the properties below are optional
+      cidrIp: "cidrIp",
+      cidrIpv6: "cidrIpv6",
+      description: "description",
+      fromPort: 123,
+      sourcePrefixListId: "sourcePrefixListId",
+      sourceSecurityGroupId: "sourceSecurityGroupId",
+      sourceSecurityGroupName: "sourceSecurityGroupName",
+      sourceSecurityGroupOwnerId: "sourceSecurityGroupOwnerId",
+      toPort: 123,
+    },
+  ],
+  tags: [
+    {
+      key: "key",
+      value: "value",
+    },
+  ],
+  vpcId: "vpcId",
+};

--- a/test/fixtures/infra/aws-iam/cfn_role.ts
+++ b/test/fixtures/infra/aws-iam/cfn_role.ts
@@ -1,0 +1,45 @@
+import { CfnRoleProps } from "@aws-cdk/aws-iam";
+
+export const CfnRoleProperties: CfnRoleProps = {
+  assumeRolePolicyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: {
+          Service: ["ec2.amazonaws.com"],
+        },
+        Action: ["sts:AssumeRole"],
+      },
+    ],
+  },
+
+  // the properties below are optional
+  description: "description",
+  managedPolicyArns: ["managedPolicyArns"],
+  maxSessionDuration: 123,
+  path: "path",
+  permissionsBoundary: "permissionsBoundary",
+  policies: [
+    {
+      policyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Action: "*",
+            Resource: "*",
+          },
+        ],
+      },
+      policyName: "policyName",
+    },
+  ],
+  roleName: "roleName",
+  tags: [
+    {
+      key: "key",
+      value: "value",
+    },
+  ],
+};

--- a/test/fixtures/infra/aws-lambda/cfn_function.ts
+++ b/test/fixtures/infra/aws-lambda/cfn_function.ts
@@ -1,0 +1,58 @@
+import { CfnFunctionProps } from "@aws-cdk/aws-lambda";
+
+export const CfnFunctionProperties: CfnFunctionProps = {
+  code: {
+    imageUri: "imageUri",
+    s3Bucket: "s3Bucket",
+    s3Key: "s3Key",
+    s3ObjectVersion: "s3ObjectVersion",
+    zipFile: "zipFile",
+  },
+  role: "role",
+
+  // the properties below are optional
+  architectures: ["architectures"],
+  codeSigningConfigArn: "codeSigningConfigArn",
+  deadLetterConfig: {
+    targetArn: "targetArn",
+  },
+  description: "description",
+  environment: {
+    variables: {
+      variablesKey: "variables",
+    },
+  },
+  fileSystemConfigs: [
+    {
+      arn: "arn",
+      localMountPath: "localMountPath",
+    },
+  ],
+  functionName: "functionName",
+  handler: "handler",
+  imageConfig: {
+    command: ["command"],
+    entryPoint: ["entryPoint"],
+    workingDirectory: "workingDirectory",
+  },
+  kmsKeyArn: "kmsKeyArn",
+  layers: ["layers"],
+  memorySize: 123,
+  packageType: "packageType",
+  reservedConcurrentExecutions: 123,
+  runtime: "runtime",
+  tags: [
+    {
+      key: "key",
+      value: "value",
+    },
+  ],
+  timeout: 123,
+  tracingConfig: {
+    mode: "mode",
+  },
+  vpcConfig: {
+    securityGroupIds: ["securityGroupIds"],
+    subnetIds: ["subnetIds"],
+  },
+};

--- a/test/infra/aspects/prefixers/ec2_cfn_security_group_prefixer.test.ts
+++ b/test/infra/aspects/prefixers/ec2_cfn_security_group_prefixer.test.ts
@@ -1,0 +1,68 @@
+import * as ec2 from "@aws-cdk/aws-ec2";
+import * as cdk from "@aws-cdk/core";
+
+import { expect as expectCDK, haveResource } from "@aws-cdk/assert";
+import { Ec2CfnSecurityGroupPrefixer } from "../../../../lib";
+import { CfnSecurityGroupProperties } from "../../../fixtures/infra/aws-ec2/cfn_security_group";
+import { EmptyResource } from "../../../fixtures/infra/empty_resource";
+
+describe("Lambda CfnSecurityGroup Prefixer", () => {
+  let app: cdk.App;
+  let stack: cdk.Stack;
+  let cfnSecurityGroup: ec2.CfnSecurityGroup;
+  let prefixer: Ec2CfnSecurityGroupPrefixer;
+  let emptyPrefixer: Ec2CfnSecurityGroupPrefixer;
+
+  beforeEach(() => {
+    app = new cdk.App();
+    stack = new cdk.Stack(app, "AspectTestStack", {});
+    cfnSecurityGroup = new ec2.CfnSecurityGroup(
+      stack,
+      "securityGroup2",
+      CfnSecurityGroupProperties
+    );
+    prefixer = new Ec2CfnSecurityGroupPrefixer(
+      cfnSecurityGroup,
+      "test-prefix-"
+    );
+    emptyPrefixer = new Ec2CfnSecurityGroupPrefixer(cfnSecurityGroup, "");
+  });
+
+  describe("Empty Prefix", () => {
+    test("Keeps group name the same", () => {
+      emptyPrefixer.prefix();
+
+      expectCDK(stack).to(
+        haveResource("AWS::EC2::SecurityGroup", {
+          GroupName: "groupName",
+        })
+      );
+    });
+  });
+
+  describe("With Prefix", () => {
+    test("Adds prefix to the start of the group name", () => {
+      prefixer.prefix();
+
+      expectCDK(stack).to(
+        haveResource("AWS::EC2::SecurityGroup", {
+          GroupName: "test-prefix-groupName",
+        })
+      );
+    });
+  });
+
+  describe("Undefined Resource", () => {
+    test("Raises error if no prefixer defined for resource", () => {
+      const unknownResource = new EmptyResource(stack, "empty", {
+        type: "EmptyResource",
+      });
+
+      expect(() => {
+        new Ec2CfnSecurityGroupPrefixer(unknownResource, "prefix");
+      }).toThrowError(
+        "Specified node is not an instance of CfnSecurityGroup and cannot be prefixed using this prefixer"
+      );
+    });
+  });
+});

--- a/test/infra/aspects/prefixers/iam_cfn_role_prefixer.test.ts
+++ b/test/infra/aspects/prefixers/iam_cfn_role_prefixer.test.ts
@@ -1,0 +1,89 @@
+import * as iam from "@aws-cdk/aws-iam";
+import * as cdk from "@aws-cdk/core";
+
+import { expect as expectCDK, haveResource } from "@aws-cdk/assert";
+import { IamCfnRolePrefixer } from "../../../../lib";
+import { CfnRoleProperties } from "../../../fixtures/infra/aws-iam/cfn_role";
+import { EmptyResource } from "../../../fixtures/infra/empty_resource";
+import { Match, Template } from "@aws-cdk/assertions";
+
+describe("IAM CfnRole Prefixer", () => {
+  let app: cdk.App;
+  let stack: cdk.Stack;
+  let cfnRole: iam.CfnRole;
+  let prefixer: IamCfnRolePrefixer;
+  let emptyPrefixer: IamCfnRolePrefixer;
+
+  beforeEach(() => {
+    app = new cdk.App();
+    stack = new cdk.Stack(app, "AspectTestStack", {});
+    cfnRole = new iam.CfnRole(stack, "role2", CfnRoleProperties);
+    prefixer = new IamCfnRolePrefixer(cfnRole, "test-prefix-");
+    emptyPrefixer = new IamCfnRolePrefixer(cfnRole, "");
+  });
+
+  describe("Empty Prefix", () => {
+    test("Keeps role name the same", () => {
+      emptyPrefixer.prefix();
+
+      expectCDK(stack).to(
+        haveResource("AWS::IAM::Role", {
+          RoleName: "roleName",
+        })
+      );
+    });
+  });
+
+  describe("With Prefix", () => {
+    test("Adds prefix to the start of the role name", () => {
+      prefixer.prefix();
+
+      expectCDK(stack).to(
+        haveResource("AWS::IAM::Role", {
+          RoleName: "test-prefix-roleName",
+        })
+      );
+    });
+
+    test("Adds prefix to the start of logical id if no role name given", () => {
+      const app = new cdk.App();
+      const stack = new cdk.Stack(app, "AspectTestStack", {});
+      const cfnRole = new iam.CfnRole(stack, "roleOther", {
+        assumeRolePolicyDocument: {
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Allow",
+              Principal: {
+                Service: ["ec2.amazonaws.com"],
+              },
+              Action: ["sts:AssumeRole"],
+            },
+          ],
+        },
+      });
+      const prefixer = new IamCfnRolePrefixer(cfnRole, "test-prefix-");
+
+      prefixer.prefix();
+
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties("AWS::IAM::Role", {
+        RoleName: Match.stringLikeRegexp("test-prefix-"),
+      });
+    });
+  });
+
+  describe("Undefined Resource", () => {
+    test("Raises error if no prefixer defined for resource", () => {
+      const unknownResource = new EmptyResource(stack, "empty", {
+        type: "EmptyResource",
+      });
+
+      expect(() => {
+        new IamCfnRolePrefixer(unknownResource, "prefix");
+      }).toThrowError(
+        "Specified node is not an instance of CfnRole and cannot be prefixed using this prefixer"
+      );
+    });
+  });
+});

--- a/test/infra/aspects/prefixers/lambda_cfn_function_prefixer.test.ts
+++ b/test/infra/aspects/prefixers/lambda_cfn_function_prefixer.test.ts
@@ -1,0 +1,65 @@
+import * as lambda from "@aws-cdk/aws-lambda";
+import * as cdk from "@aws-cdk/core";
+
+import { expect as expectCDK, haveResource } from "@aws-cdk/assert";
+import { LambdaCfnFunctionPrefixer } from "../../../../lib";
+import { CfnFunctionProperties } from "../../../fixtures/infra/aws-lambda/cfn_function";
+import { EmptyResource } from "../../../fixtures/infra/empty_resource";
+
+describe("Lambda CfnFunction Prefixer", () => {
+  let app: cdk.App;
+  let stack: cdk.Stack;
+  let cfnFunction: lambda.CfnFunction;
+  let prefixer: LambdaCfnFunctionPrefixer;
+  let emptyPrefixer: LambdaCfnFunctionPrefixer;
+
+  beforeEach(() => {
+    app = new cdk.App();
+    stack = new cdk.Stack(app, "AspectTestStack", {});
+    cfnFunction = new lambda.CfnFunction(
+      stack,
+      "function2",
+      CfnFunctionProperties
+    );
+    prefixer = new LambdaCfnFunctionPrefixer(cfnFunction, "test-prefix-");
+    emptyPrefixer = new LambdaCfnFunctionPrefixer(cfnFunction, "");
+  });
+
+  describe("Empty Prefix", () => {
+    test("Keeps function name the same", () => {
+      emptyPrefixer.prefix();
+
+      expectCDK(stack).to(
+        haveResource("AWS::Lambda::Function", {
+          FunctionName: "functionName",
+        })
+      );
+    });
+  });
+
+  describe("With Prefix", () => {
+    test("Adds prefix to the start of the function name", () => {
+      prefixer.prefix();
+
+      expectCDK(stack).to(
+        haveResource("AWS::Lambda::Function", {
+          FunctionName: "test-prefix-functionName",
+        })
+      );
+    });
+  });
+
+  describe("Undefined Resource", () => {
+    test("Raises error if no prefixer defined for resource", () => {
+      const unknownResource = new EmptyResource(stack, "empty", {
+        type: "EmptyResource",
+      });
+
+      expect(() => {
+        new LambdaCfnFunctionPrefixer(unknownResource, "prefix");
+      }).toThrowError(
+        "Specified node is not an instance of CfnFunction and cannot be prefixed using this prefixer"
+      );
+    });
+  });
+});


### PR DESCRIPTION
Refactored the CfnResourcePrefixers to use an abstract base class and add prefixers for the following:

- CfnSecurityGroup (aws-ec2)
- CfnRole (aws-iam)
- CfnFunction (aws-lambda)

This extracts the work done on https://github.com/talis/talis-cdk-constructs/tree/sm08_add_lambda_prefixer 