### PR TITLE
fix: truncate prefixed name to 64 characters

### DIFF
--- a/lib/aspects/resource_prefixer/cfn_resource_prefixer.ts
+++ b/lib/aspects/resource_prefixer/cfn_resource_prefixer.ts
@@ -1,5 +1,7 @@
 import { IConstruct, CfnResource, Token } from "@aws-cdk/core";
 
+const MAX_LENGTH = 64;
+
 export interface CfnResourcePrefixer {
   prefix(): void;
 }
@@ -24,18 +26,18 @@ export abstract class CfnResourcePrefixerBase implements CfnResourcePrefixer {
     name: string | undefined,
     propertyPath: string
   ): void {
+    let prefixedName;
     if (!Token.isUnresolved(name)) {
-      this.node.addPropertyOverride(
-        propertyPath,
-        `${this.resourcePrefix}${name}`
-      );
+      prefixedName = `${this.resourcePrefix}${name}`;
     } else {
       const logicalId = this.node.stack.getLogicalId(this.node);
-      this.node.addPropertyOverride(
-        propertyPath,
-        `${this.resourcePrefix}${logicalId}`
-      );
+      prefixedName = `${this.resourcePrefix}${logicalId}`;
     }
+
+    this.node.addPropertyOverride(
+      propertyPath,
+      prefixedName.substring(0, MAX_LENGTH)
+    );
   }
 
   public prefix() {

--- a/test/infra/aspects/resource_prefixer.test.ts
+++ b/test/infra/aspects/resource_prefixer.test.ts
@@ -2,6 +2,7 @@ import * as cdk from "@aws-cdk/core";
 
 import { expect as expectCDK, haveResource } from "@aws-cdk/assert";
 import { Annotations, Template } from "@aws-cdk/assertions";
+import { Role, ServicePrincipal } from "@aws-cdk/aws-iam";
 import { ResourcePrefixer } from "../../../lib";
 import { Aspects } from "@aws-cdk/core";
 import { EmptyResource } from "../../fixtures/infra/empty_resource";
@@ -52,6 +53,23 @@ describe("Resource Prefixer", () => {
         expectCDK(stack).to(haveResource(expectedType, expectedPropsPrefixed));
       }
     );
+  });
+
+  describe("Truncates long resource names", () => {
+    test("reduces name to 64 characters if longer", () => {
+      new Role(stack, "id", {
+        roleName:
+          "kYTwwGzerWgBAZEnEKbuUnvLzFnZhRiuDAWlmjpOZhebJYTNKOcxuJDvjwzthdiIKvjVbYmSAuIwprweKYTlOjhQtptvGPCMaFsdRuufBYBhvykpxISQbeGgDXLnFxYqZSkAjZMJchsj",
+        assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
+      });
+      Aspects.of(stack).add(resourcePrefixer);
+      expectCDK(stack).to(
+        haveResource("AWS::IAM::Role", {
+          RoleName:
+            "test-prefix-kYTwwGzerWgBAZEnEKbuUnvLzFnZhRiuDAWlmjpOZhebJYTNKOcx",
+        })
+      );
+    });
   });
 
   describe("Undefined Resources", () => {


### PR DESCRIPTION
AWS expects names to be 64 characters or less, this updates the prefixer aspect to truncate names longer than 64 characters when using logical ID for the name