### PR TITLE
feat: ele-5228 update talis node version to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9842,6 +9842,31 @@
         }
       }
     },
+    "request-promise-core": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+      "requires": {
+        "lodash": "^4.17.19"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        }
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
+      "requires": {
+        "request-promise-core": "1.1.4",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -10678,6 +10703,11 @@
         }
       }
     },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+    },
     "stream-combiner2": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
@@ -10857,21 +10887,27 @@
       }
     },
     "talis-node": {
-      "version": "git+https://github.com/talis/talis-node.git#55fa339a6958236f30a8701a7dee510f2724c6c3",
-      "from": "git+https://github.com/talis/talis-node.git#v0.0.3",
+      "version": "git+https://github.com/talis/talis-node.git#61c77293aa55ed3c33d2db80ca500ee16d6bd9bb",
+      "from": "git+https://github.com/talis/talis-node.git#v0.1.9",
       "requires": {
         "cache-service": "1.3.5",
         "cache-service-node-cache": "2.0.0",
         "cache-service-redis": "2.0.0",
         "crypto-js": "3.1.2-2",
         "jsonwebtoken": "5.7.0",
-        "lodash": "4.17.11",
+        "lodash": "4.17.21",
         "md5": "2.2.1",
         "node-cache": "4.2.0",
         "request": "2.88.0",
+        "request-promise-native": "^1.0.8",
         "uuid": "2.0.2"
       },
       "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
         "uuid": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@aws-cdk/aws-sqs": "1.143.0",
     "@aws-cdk/core": "1.143.0",
     "cdk-ecr-deployment": "1.0.2",
-    "talis-node": "https://github.com/talis/talis-node.git#v0.0.3",
+    "talis-node": "https://github.com/talis/talis-node.git#v0.1.9",
     "uuid": "8.3.2"
   }
 }


### PR DESCRIPTION
### Problem

* talis/elevate-app#5228

Otis and Elevate report a security vulnerability in Lodash that comes from a dependency of this repo.

This vulnerability was fixed in `talis-node` here: https://github.com/talis/talis-node/pull/29

### Fix

Updates the version of `talis-node` to `v0.1.9`.

This version has an upgraded version of Lodash which resolves a security vulnerability.

