### PR TITLE
feat: plat-5576 make vpc optional in api and worker constructs

### DIFF
--- a/examples/simple-authenticated-api/lib/simple-authenticated-api-stack.ts
+++ b/examples/simple-authenticated-api/lib/simple-authenticated-api-stack.ts
@@ -29,9 +29,10 @@ export class SimpleAuthenticatedApiStack extends cdk.Stack {
       { topicName: `${prefix}simple-authenticated-api-alarm` }
     );
 
-    const vpc = ec2.Vpc.fromLookup(this, `${prefix}-vpc`, {
-      vpcId: "vpc-0155db5e1ab5c28b6",
-    });
+    // VPC is optional. To use one, you would look it up as follows:
+    // const vpc = ec2.Vpc.fromLookup(this, `${prefix}-vpc`, {
+    //   vpcId: "vpc-0155db5e1ab5c28b6",
+    // });
 
     // Setting a security group is an option. This is an example of importing and using a
     // pre existing security group. This one is defined in terraform.
@@ -61,7 +62,9 @@ export class SimpleAuthenticatedApiStack extends cdk.Stack {
         handler: "route",
         timeout: cdk.Duration.seconds(30),
         securityGroups: lambdaSecurityGroups,
-        vpc: vpc,
+        // A VPC is optional. If you need to specify one, you would do so here:
+        // vpc: vpc,
+        // vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_NAT },
       }
     );
 
@@ -75,7 +78,9 @@ export class SimpleAuthenticatedApiStack extends cdk.Stack {
         handler: "route",
         timeout: cdk.Duration.seconds(30),
         securityGroups: lambdaSecurityGroups,
-        vpc: vpc,
+        // A VPC is optional. If you need to specify one, you would do so here:
+        // vpc: vpc,
+        // vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_NAT },
       }
     );
 
@@ -88,8 +93,9 @@ export class SimpleAuthenticatedApiStack extends cdk.Stack {
         description: "A simple example API",
         stageName: "development", // This should be development / staging / production as appropriate
         alarmTopic,
-        vpc,
-        vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_NAT },
+        // A VPC is optional. If you need to specify one, you would do so here:
+        // vpc: vpc,
+        // vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_NAT },
         securityGroups: lambdaSecurityGroups,
         domainName: `${prefix}simple-authenticated-api.talis.com`,
         certificateArn: STAGING_TALIS_TLS_CERT_ARN,

--- a/examples/simple-lambda-worker/lib/simple-lambda-worker-stack.ts
+++ b/examples/simple-lambda-worker/lib/simple-lambda-worker-stack.ts
@@ -37,9 +37,10 @@ export class SimpleLambdaWorkerStack extends cdk.Stack {
       { topicName: `${prefix}simple-lambda-worker-alarm` }
     );
 
-    const vpc = ec2.Vpc.fromLookup(this, `${prefix}-vpc`, {
-      vpcId: "vpc-0155db5e1ab5c28b6",
-    });
+    // VPC is optional. To use one, you would look it up as follows:
+    // const vpc = ec2.Vpc.fromLookup(this, `${prefix}-vpc`, {
+    //   vpcId: "vpc-0155db5e1ab5c28b6",
+    // });
 
     // Setting a security group is an option. This is an example of importing and using a
     // pre existing security group. This one is defined in terraform.
@@ -83,8 +84,9 @@ export class SimpleLambdaWorkerStack extends cdk.Stack {
           memorySize: 1024,
           securityGroups: lambdaSecurityGroups,
           timeout: cdk.Duration.seconds(30),
-          vpc: vpc,
-          vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_NAT },
+          // A VPC is optional. If you need to specify one, you would do so here:
+          // vpc: vpc,
+          // vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_NAT },
           policyStatements: [
             new iam.PolicyStatement({
               effect: iam.Effect.ALLOW,

--- a/lib/authenticated-api/authenticated-api-function-props.ts
+++ b/lib/authenticated-api/authenticated-api-function-props.ts
@@ -7,7 +7,8 @@ export interface AuthenticatedApiFunctionProps {
   environment?: { [key: string]: string };
   handler: string;
   timeout: cdk.Duration;
-  vpc: ec2.IVpc;
+  vpc?: ec2.IVpc;
+  vpcSubnets?: ec2.SubnetSelection;
   securityGroups: Array<ec2.ISecurityGroup>;
   memorySize?: number;
 }

--- a/lib/authenticated-api/authenticated-api-function.ts
+++ b/lib/authenticated-api/authenticated-api-function.ts
@@ -32,7 +32,7 @@ export class AuthenticatedApiFunction extends lambdaNode.NodejsFunction {
       timeout: props.timeout,
       securityGroups: props.securityGroups,
       vpc: props.vpc,
-      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_NAT },
+      vpcSubnets: props.vpcSubnets,
     });
   }
 }

--- a/lib/authenticated-api/authenticated-api-props.ts
+++ b/lib/authenticated-api/authenticated-api-props.ts
@@ -11,8 +11,8 @@ export interface AuthenticatedApiProps {
   stageName: string;
   routes: Array<RouteLambdaProps>;
   securityGroups?: Array<ec2.ISecurityGroup>;
-  vpc: ec2.IVpc;
-  vpcSubnets: ec2.SubnetSelection;
+  vpc?: ec2.IVpc;
+  vpcSubnets?: ec2.SubnetSelection;
   domainName: string;
   certificateArn: string;
   corsDomain?: string[];

--- a/lib/lambda-worker/lambda-worker-props.ts
+++ b/lib/lambda-worker/lambda-worker-props.ts
@@ -27,8 +27,8 @@ export interface LambdaWorkerProps {
     retryAttempts?: number;
     securityGroups?: Array<ec2.ISecurityGroup>;
     timeout: cdk.Duration;
-    vpc: ec2.IVpc;
-    vpcSubnets: ec2.SubnetSelection;
+    vpc?: ec2.IVpc;
+    vpcSubnets?: ec2.SubnetSelection;
   };
 
   // Queue Properties


### PR DESCRIPTION
- https://github.com/talis/platform/issues/5576

This PR makes the VPC optional for both the Lambda Worker and Authenticated API constructs.

It changes the examples to not use a VPC, but leaves how you would do so as an example comment.