### PR TITLE
chore: revert "feat: plat-5576 make vpc optional in api and worker constructs"

### DIFF
--- a/examples/simple-authenticated-api/lib/simple-authenticated-api-stack.ts
+++ b/examples/simple-authenticated-api/lib/simple-authenticated-api-stack.ts
@@ -29,10 +29,9 @@ export class SimpleAuthenticatedApiStack extends cdk.Stack {
       { topicName: `${prefix}simple-authenticated-api-alarm` }
     );
 
-    // VPC is optional. To use one, you would look it up as follows:
-    // const vpc = ec2.Vpc.fromLookup(this, `${prefix}-vpc`, {
-    //   vpcId: "vpc-0155db5e1ab5c28b6",
-    // });
+    const vpc = ec2.Vpc.fromLookup(this, `${prefix}-vpc`, {
+      vpcId: "vpc-0155db5e1ab5c28b6",
+    });
 
     // Setting a security group is an option. This is an example of importing and using a
     // pre existing security group. This one is defined in terraform.
@@ -62,9 +61,7 @@ export class SimpleAuthenticatedApiStack extends cdk.Stack {
         handler: "route",
         timeout: cdk.Duration.seconds(30),
         securityGroups: lambdaSecurityGroups,
-        // A VPC is optional. If you need to specify one, you would do so here:
-        // vpc: vpc,
-        // vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_NAT },
+        vpc: vpc,
       }
     );
 
@@ -78,9 +75,7 @@ export class SimpleAuthenticatedApiStack extends cdk.Stack {
         handler: "route",
         timeout: cdk.Duration.seconds(30),
         securityGroups: lambdaSecurityGroups,
-        // A VPC is optional. If you need to specify one, you would do so here:
-        // vpc: vpc,
-        // vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_NAT },
+        vpc: vpc,
       }
     );
 
@@ -93,9 +88,8 @@ export class SimpleAuthenticatedApiStack extends cdk.Stack {
         description: "A simple example API",
         stageName: "development", // This should be development / staging / production as appropriate
         alarmTopic,
-        // A VPC is optional. If you need to specify one, you would do so here:
-        // vpc: vpc,
-        // vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_NAT },
+        vpc,
+        vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_NAT },
         securityGroups: lambdaSecurityGroups,
         domainName: `${prefix}simple-authenticated-api.talis.com`,
         certificateArn: STAGING_TALIS_TLS_CERT_ARN,

--- a/examples/simple-lambda-worker/lib/simple-lambda-worker-stack.ts
+++ b/examples/simple-lambda-worker/lib/simple-lambda-worker-stack.ts
@@ -37,10 +37,9 @@ export class SimpleLambdaWorkerStack extends cdk.Stack {
       { topicName: `${prefix}simple-lambda-worker-alarm` }
     );
 
-    // VPC is optional. To use one, you would look it up as follows:
-    // const vpc = ec2.Vpc.fromLookup(this, `${prefix}-vpc`, {
-    //   vpcId: "vpc-0155db5e1ab5c28b6",
-    // });
+    const vpc = ec2.Vpc.fromLookup(this, `${prefix}-vpc`, {
+      vpcId: "vpc-0155db5e1ab5c28b6",
+    });
 
     // Setting a security group is an option. This is an example of importing and using a
     // pre existing security group. This one is defined in terraform.
@@ -84,9 +83,8 @@ export class SimpleLambdaWorkerStack extends cdk.Stack {
           memorySize: 1024,
           securityGroups: lambdaSecurityGroups,
           timeout: cdk.Duration.seconds(30),
-          // A VPC is optional. If you need to specify one, you would do so here:
-          // vpc: vpc,
-          // vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_NAT },
+          vpc: vpc,
+          vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_NAT },
           policyStatements: [
             new iam.PolicyStatement({
               effect: iam.Effect.ALLOW,

--- a/lib/authenticated-api/authenticated-api-function-props.ts
+++ b/lib/authenticated-api/authenticated-api-function-props.ts
@@ -7,8 +7,7 @@ export interface AuthenticatedApiFunctionProps {
   environment?: { [key: string]: string };
   handler: string;
   timeout: cdk.Duration;
-  vpc?: ec2.IVpc;
-  vpcSubnets?: ec2.SubnetSelection;
+  vpc: ec2.IVpc;
   securityGroups: Array<ec2.ISecurityGroup>;
   memorySize?: number;
 }

--- a/lib/authenticated-api/authenticated-api-function.ts
+++ b/lib/authenticated-api/authenticated-api-function.ts
@@ -32,7 +32,7 @@ export class AuthenticatedApiFunction extends lambdaNode.NodejsFunction {
       timeout: props.timeout,
       securityGroups: props.securityGroups,
       vpc: props.vpc,
-      vpcSubnets: props.vpcSubnets,
+      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_NAT },
     });
   }
 }

--- a/lib/authenticated-api/authenticated-api-props.ts
+++ b/lib/authenticated-api/authenticated-api-props.ts
@@ -11,8 +11,8 @@ export interface AuthenticatedApiProps {
   stageName: string;
   routes: Array<RouteLambdaProps>;
   securityGroups?: Array<ec2.ISecurityGroup>;
-  vpc?: ec2.IVpc;
-  vpcSubnets?: ec2.SubnetSelection;
+  vpc: ec2.IVpc;
+  vpcSubnets: ec2.SubnetSelection;
   domainName: string;
   certificateArn: string;
   corsDomain?: string[];

--- a/lib/lambda-worker/lambda-worker-props.ts
+++ b/lib/lambda-worker/lambda-worker-props.ts
@@ -27,8 +27,8 @@ export interface LambdaWorkerProps {
     retryAttempts?: number;
     securityGroups?: Array<ec2.ISecurityGroup>;
     timeout: cdk.Duration;
-    vpc?: ec2.IVpc;
-    vpcSubnets?: ec2.SubnetSelection;
+    vpc: ec2.IVpc;
+    vpcSubnets: ec2.SubnetSelection;
   };
 
   // Queue Properties


### PR DESCRIPTION
Reverts talis/talis-cdk-constructs#48

This PR reverts the previous PR to make VPC's optional. There is nothing wrong with the PR itself, however because it only had one commit, github's did not need to squash the commits when it was merged. This means it did not used the PR title as the message for the squash commit. The commit message on the branch does not conform to conventional commits. This meant that no version was released:

![release](https://user-images.githubusercontent.com/232529/167618284-f1047945-2b86-4168-9153-5e5647441333.png)

Merging this PR will still fail to create a release, because the single commit comment created by github when you hit the revert button also doesn't comply with conventional commits.

After this is reverted - we can revert the revert and add a second commit, which will create a PR which will trigger a release.
