### PR TITLE
fix: plat-5537 add authoriser.ts files to distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "files": [
     "lib/**/*.d.ts",
     "lib/**/*.js",
-    "src/**/*.js"
+    "src/**/*.js",
+    "src/lambda/api/authorizer.ts",
+    "src/lambda/api/authorizer.d.ts"
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
We have converted the authoeriser function from javascript to typescript. The distribution only contains the compiled javascript file.

This has caused an issue that the authenticated api construct is referencing a `.ts` file. When this library is pulled into another project, the `.ts` file is missing.

We discussed various options:

- compiling the .`ts` file ourselves rather than having the AWS CDK  compile it.
- pulling the authoriser code out into it's own repo so it could be include in projects directly
- deploying the authoriser function as a service
- moving to the jwt approach we want to get to now, which would require persona changes
- adding the `.ts` file to the distribution

The decision was that we want to move to the jwt approach, but we can not do that right now. Therefore add the `.ts` file into the distribution is the smallest amount of work until we can get to that.