### PR TITLE
fix!: deploy SPA websiteIndexDocument last

### DIFF
--- a/lib/cdn-site-hosting/cdn-site-hosting-props.ts
+++ b/lib/cdn-site-hosting/cdn-site-hosting-props.ts
@@ -17,4 +17,5 @@ export interface CommonCdnSiteHostingProps {
   sourcesWithDeploymentOptions?: SourcesWithDeploymentOptions[];
   websiteErrorDocument?: string;
   websiteIndexDocument: string;
+  websiteIndexDocumentAsset?: s3deploy.ISource;
 }

--- a/test/infra/cdn-site-hosting/cdn-site-hosting-construct.test.ts
+++ b/test/infra/cdn-site-hosting/cdn-site-hosting-construct.test.ts
@@ -159,7 +159,7 @@ describe("CdnSiteHostingConstruct", () => {
             websiteErrorDocument: "error.html",
             websiteIndexDocument: "/index.html",
           })
-      ).toThrow("leading slashes are not allowed in websiteIndexDocument");
+      ).toThrow("Leading slashes are not allowed in websiteIndexDocument");
     });
   });
 
@@ -175,8 +175,11 @@ describe("CdnSiteHostingConstruct", () => {
         domainName: fakeDomain,
         removalPolicy: RemovalPolicy.DESTROY,
         isRoutedSpa: true,
-        sources: [s3deploy.Source.asset("./")],
+        sources: [s3deploy.Source.asset("./", { exclude: ["index.html"] })],
         websiteIndexDocument: "index.html",
+        websiteIndexDocumentAsset: s3deploy.Source.asset("./", {
+          exclude: ["*", "!index.html"],
+        }),
       });
     });
 
@@ -195,6 +198,7 @@ describe("CdnSiteHostingConstruct", () => {
         })
       );
     });
+
     test("configures an error document in S3", () => {
       expectCDK(stack).to(
         haveResourceLike("AWS::S3::Bucket", {
@@ -219,9 +223,12 @@ describe("CdnSiteHostingConstruct", () => {
         domainName: fakeDomain,
         removalPolicy: RemovalPolicy.DESTROY,
         isRoutedSpa: true,
-        sources: [s3deploy.Source.asset("./")],
+        sources: [s3deploy.Source.asset("./", { exclude: ["index.html"] })],
         websiteErrorDocument: "error.html",
         websiteIndexDocument: "index.html",
+        websiteIndexDocumentAsset: s3deploy.Source.asset("./", {
+          exclude: ["*", "!index.html"],
+        }),
       });
     });
 
@@ -240,6 +247,7 @@ describe("CdnSiteHostingConstruct", () => {
         })
       );
     });
+
     test("configures an error document in S3", () => {
       expectCDK(stack).to(
         haveResourceLike("AWS::S3::Bucket", {

--- a/test/infra/cdn-site-hosting/cdn-site-hosting-with-dns-construct.test.ts
+++ b/test/infra/cdn-site-hosting/cdn-site-hosting-with-dns-construct.test.ts
@@ -175,8 +175,11 @@ describe("CdnSiteHostingWithDnsConstruct", () => {
         domainName: fakeDomain,
         removalPolicy: RemovalPolicy.DESTROY,
         isRoutedSpa: true,
-        sources: [s3deploy.Source.asset("./")],
+        sources: [s3deploy.Source.asset("./", { exclude: ["index.html"] })],
         websiteIndexDocument: "index.html",
+        websiteIndexDocumentAsset: s3deploy.Source.asset("./", {
+          exclude: ["*", "!index.html"],
+        }),
       });
     });
 
@@ -218,9 +221,12 @@ describe("CdnSiteHostingWithDnsConstruct", () => {
         domainName: fakeDomain,
         removalPolicy: RemovalPolicy.DESTROY,
         isRoutedSpa: true,
-        sources: [s3deploy.Source.asset("./")],
+        sources: [s3deploy.Source.asset("./", { exclude: ["index.html"] })],
         websiteErrorDocument: "error.html",
         websiteIndexDocument: "index.html",
+        websiteIndexDocumentAsset: s3deploy.Source.asset("./", {
+          exclude: ["*", "!index.html"],
+        }),
       });
     });
 


### PR DESCRIPTION
BREAKING CHANGE: Routed SPAs must specify a websiteIndexDocumentAsset that points to the source of the websiteIndexDocument asset.

For routed SPAs, deploy and invalidate websiteIndexDocument only after all other assets have been deployed, to ensure deployment does not cause downtime.