### PR TITLE
feat: honour cdn-site-hosting source deployment order

### DIFF
--- a/lib/cdn-site-hosting/cdn-site-hosting-construct.ts
+++ b/lib/cdn-site-hosting/cdn-site-hosting-construct.ts
@@ -31,10 +31,6 @@ export class CdnSiteHostingConstruct extends cdk.Construct {
   ) {
     super(scope, id);
 
-    if (props.websiteIndexDocument.startsWith("/")) {
-      throw Error("leading slashes are not allowed in websiteIndexDocument");
-    }
-
     validateProps(props);
 
     const siteDomain = getSiteDomain(props);
@@ -157,7 +153,7 @@ export class CdnSiteHostingConstruct extends cdk.Construct {
 }
 
 function validateProps(props: CdnSiteHostingConstructProps): void {
-  const { sources, sourcesWithDeploymentOptions } = props;
+  const { sources, sourcesWithDeploymentOptions, websiteIndexDocument } = props;
 
   // validate source specfications
   if (!sources && !sourcesWithDeploymentOptions) {
@@ -182,5 +178,9 @@ function validateProps(props: CdnSiteHostingConstructProps): void {
     throw new Error("`sourcesWithDeploymentOptions.sources` cannot be empty");
   } else if (sources && sources.length === 0) {
     throw new Error("If specified, `sources` cannot be empty");
+  }
+
+  if (websiteIndexDocument.startsWith("/")) {
+    throw Error("leading slashes are not allowed in websiteIndexDocument");
   }
 }

--- a/lib/cdn-site-hosting/cdn-site-hosting-construct.ts
+++ b/lib/cdn-site-hosting/cdn-site-hosting-construct.ts
@@ -155,7 +155,7 @@ export class CdnSiteHostingConstruct extends cdk.Construct {
 function validateProps(props: CdnSiteHostingConstructProps): void {
   const { sources, sourcesWithDeploymentOptions, websiteIndexDocument } = props;
 
-  // validate source specfications
+  // validate source specifications
   if (!sources && !sourcesWithDeploymentOptions) {
     throw new Error(
       "Either `sources` or `sourcesWithDeploymentOptions` must be specified"


### PR DESCRIPTION
When deploying assets to S3 via CDK, ensure the order of the sources given in config is honoured.

This allows routed SPAs to explicitly deploy the `websiteIndexDocument` last, after all other assets have been deployed, avoiding any downtime caused by the `websiteIndexDocument` pointing to missing assets.

- See https://github.com/talis/elevate-app/issues/5746