### PR TITLE
chore: re-enable commit linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,12 @@ workflows:
   build:
     jobs:
       - fan_out
-      - commit-lint-branch
+      - commit-lint-branch:
+          filters:
+            branches:
+              ignore:
+                - main
+                - /^dependabot-.*$/
       - be_kind_to_your_colleagues:
           type: approval
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,19 @@ jobs:
       - run:
           command: echo "starting build"
       - save_root_build_number
-
+  commit-lint-branch:
+    executor: default_executor
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "ee:b4:00:e6:23:5b:55:bb:fd:07:bc:73:9e:f7:89:9c" # shared.aspire@talis.com 'talis-cdk-constructs Deploy Key'
+      - checkout
+      - node/install-packages
+      - run:
+          name: Lint all commits on the branch
+          command: |
+            FIRST_COMMIT=$(git log main..$CIRCLE_BRANCH --oneline | tail -1 | awk '{ print $1 }')
+            npx commitlint --from $FIRST_COMMIT --to $CIRCLE_SHA1 --verbose
   build:
     executor: default_executor
     steps:
@@ -137,6 +149,7 @@ workflows:
   build:
     jobs:
       - fan_out
+      - commit-lint-branch
       - be_kind_to_your_colleagues:
           type: approval
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,8 +52,12 @@ jobs:
       - run:
           name: Lint all commits on the branch
           command: |
-            FIRST_COMMIT=$(git log main..$CIRCLE_BRANCH --oneline | tail -1 | awk '{ print $1 }')
-            npx commitlint --from $FIRST_COMMIT --to $CIRCLE_SHA1 --verbose
+            # FIRST_COMMIT=$(git log main..$CIRCLE_BRANCH --oneline | tail -1 | awk '{ print $1 }')
+            FIRST_COMMIT=$(git merge-base main $CIRCLE_BRANCH)
+            LAST_COMMIT=$(git rev-parse HEAD)
+            echo "FIRST COMMIT: $FIRST_COMMIT"
+            echo "LAST COMMIT : $LAST_COMMIT"
+            npx commitlint --from $FIRST_COMMIT --to $LAST_COMMIT --verbose
   build:
     executor: default_executor
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,6 @@ jobs:
       - run:
           name: Lint all commits on the branch
           command: |
-            # FIRST_COMMIT=$(git log main..$CIRCLE_BRANCH --oneline | tail -1 | awk '{ print $1 }')
             FIRST_COMMIT=$(git merge-base main $CIRCLE_BRANCH)
             LAST_COMMIT=$(git rev-parse HEAD)
             echo "FIRST COMMIT: $FIRST_COMMIT"

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+. "$(dirname "$0")/_/husky.sh"
+
+npx --no-install commitlint --edit $1

--- a/package-lock.json
+++ b/package-lock.json
@@ -5385,6 +5385,12 @@
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
       "dev": true
     },
+    "husky": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
+      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
+      "dev": true
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -8167,8 +8173,8 @@
             "binary-extensions": "^2.2.0",
             "diff": "^5.0.0",
             "minimatch": "^3.0.4",
-            "npm-package-arg": "^8.1.1",
-            "pacote": "^11.3.0",
+            "npm-package-arg": "^8.1.4",
+            "pacote": "^11.3.4",
             "tar": "^6.1.0"
           }
         },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint": "npm run lint:prettier && npm run lint:eslint",
     "format:prettier": "prettier --write .",
     "format": "npm run format:prettier",
-    "prepare": "npm run build"
+    "prepare": "husky install && npm run build"
   },
   "devDependencies": {
     "@aws-cdk/assert": "1.143.0",
@@ -39,6 +39,7 @@
     "esbuild": "^0.13.8",
     "eslint": "^7.30.0",
     "eslint-config-prettier": "^8.3.0",
+    "husky": "^7.0.4",
     "jest": "^26.4.2",
     "prettier": "^2.3.2",
     "semantic-release": "^17.4.4",


### PR DESCRIPTION
- This relates to talis/platform#5578

This P/R achieves the following
- [x] re-introduces husky locally for those developers who are happy to use it to prevent them from violating conventional commits by using `commitlint` as a git hook.
- [x] introduces a new workflow step `commit-lint-branch` which will fail the build (so you won't be able to merge) but does not prevent a developer from running tests on their branch.
  - [x] for this to work correctly we need to work out when the branch was created and use that commit as the starting point or `--from`. The first actual commit on a branch cannot be used because it checks every commit *after* it but not including.
  - [x] this is the difference btw `git merge-base main <branch>` vs ` git log main..<branch> --oneline | tail -1 | awk '{ print $1 }'`
- [x] Finally the `commit-lint-branch` step will not run against `main` when your branch is merged. This is because there are numerous commits on main that already violate conventional commits.


## Failing build, does not prevent dev running tests on branch

![image](https://user-images.githubusercontent.com/1135464/173761606-7df2f944-44f9-428b-8430-5dde4969d67d.png)

## output from job (deliberately set to verbose)

![image](https://user-images.githubusercontent.com/1135464/173762200-b200c2dd-37fd-4f40-9bfc-648a23261b11.png)