### PR TITLE
feat: plat-5577 api construct exposes the domain name

### DIFF
--- a/examples/simple-authenticated-api/lib/simple-authenticated-api-stack.ts
+++ b/examples/simple-authenticated-api/lib/simple-authenticated-api-stack.ts
@@ -154,5 +154,8 @@ export class SimpleAuthenticatedApiStack extends cdk.Stack {
       path: "/api-documentation",
       method: apigatewayv2.HttpMethod.GET,
     });
+
+    console.log(`Regional domain name: ${api.domainName.regionalDomainName}`);
+    console.log(`Regional hosted zone id: ${api.domainName.regionalHostedZoneId}`);
   }
 }

--- a/examples/simple-authenticated-api/lib/simple-authenticated-api-stack.ts
+++ b/examples/simple-authenticated-api/lib/simple-authenticated-api-stack.ts
@@ -156,6 +156,8 @@ export class SimpleAuthenticatedApiStack extends cdk.Stack {
     });
 
     console.log(`Regional domain name: ${api.domainName.regionalDomainName}`);
-    console.log(`Regional hosted zone id: ${api.domainName.regionalHostedZoneId}`);
+    console.log(
+      `Regional hosted zone id: ${api.domainName.regionalHostedZoneId}`
+    );
   }
 }

--- a/lib/authenticated-api/authenticated-api.ts
+++ b/lib/authenticated-api/authenticated-api.ts
@@ -20,6 +20,7 @@ const DEFAULT_LAMBDA_DURATION_THRESHOLD = cdk.Duration.minutes(1);
 export class AuthenticatedApi extends cdk.Construct {
   readonly apiId: string;
   readonly httpApiId: string;
+  readonly domainName: apigatewayv2.DomainName
 
   private httpApi: apigatewayv2.HttpApi;
   private authorizer: apigatewayv2.IHttpRouteAuthorizer;
@@ -36,7 +37,7 @@ export class AuthenticatedApi extends cdk.Construct {
         `To use a custom domain name both certificateArn and domainName must be specified`
       );
     }
-    const domainName = new apigatewayv2.DomainName(this, "domain-name", {
+    this.domainName = new apigatewayv2.DomainName(this, "domain-name", {
       domainName: props.domainName,
       certificate: acm.Certificate.fromCertificateArn(
         this,
@@ -46,7 +47,7 @@ export class AuthenticatedApi extends cdk.Construct {
     });
     const apiGatewayProps: apigatewayv2.HttpApiProps = {
       apiName: `${props.prefix}${props.name}`,
-      defaultDomainMapping: { domainName: domainName },
+      defaultDomainMapping: { domainName: this.domainName },
       ...(props.corsDomain && {
         corsPreflight: {
           allowHeaders: ["*"],

--- a/lib/authenticated-api/authenticated-api.ts
+++ b/lib/authenticated-api/authenticated-api.ts
@@ -20,7 +20,7 @@ const DEFAULT_LAMBDA_DURATION_THRESHOLD = cdk.Duration.minutes(1);
 export class AuthenticatedApi extends cdk.Construct {
   readonly apiId: string;
   readonly httpApiId: string;
-  readonly domainName: apigatewayv2.DomainName
+  readonly domainName: apigatewayv2.DomainName;
 
   private httpApi: apigatewayv2.HttpApi;
   private authorizer: apigatewayv2.IHttpRouteAuthorizer;


### PR DESCRIPTION
- https://github.com/talis/platform/issues/5577

This PR makes the `domainName` object a read only attribute from the API construct.

This is needed for Smalti which is using the regional domain name and the regional hosted zone id.