### PR TITLE
fix: plat-5879 - correct alarm on lambda worker

### DIFF
--- a/lib/lambda-worker/lambda-worker.ts
+++ b/lib/lambda-worker/lambda-worker.ts
@@ -159,7 +159,7 @@ export class LambdaWorker extends cdk.Construct {
     dlqMessagesVisable.addOkAction(alarmAction);
 
     // Add an alarm for the age of the oldest message on the LambdaWorkers main trigger queue
-    const approximateAgeOfOldestMessageMetric = lambdaDLQ
+    const approximateAgeOfOldestMessageMetric = lambdaQueue
       .metric("ApproximateAgeOfOldestMessage")
       .with({ statistic: "average", period: cdk.Duration.minutes(1) });
     const queueMessagesAge = new cloudwatch.Alarm(

--- a/test/infra/lambda-worker/lambda-worker.test.ts
+++ b/test/infra/lambda-worker/lambda-worker.test.ts
@@ -619,7 +619,7 @@ describe("LambdaWorker", () => {
                 Name: "QueueName",
                 Value: {
                   "Fn::GetAtt": [
-                    "MyTestLambdaWorkerMyTestLambdaWorkerdlq27BBFD95",
+                    "MyTestLambdaWorkerMyTestLambdaWorkerqueue01D6E79E",
                     "QueueName",
                   ],
                 },

--- a/test/infra/lambda-worker/lambda-worker.test.ts
+++ b/test/infra/lambda-worker/lambda-worker.test.ts
@@ -183,7 +183,7 @@ describe("LambdaWorker", () => {
                 Name: "QueueName",
                 Value: {
                   "Fn::GetAtt": [
-                    "MyTestLambdaWorkerMyTestLambdaWorkerdlq27BBFD95",
+                    "MyTestLambdaWorkerMyTestLambdaWorkerqueue01D6E79E",
                     "QueueName",
                   ],
                 },


### PR DESCRIPTION
- https://github.com/talis/platform/issues/5879

This PR fixes an alarm on the LambdaWorker.

The alarm for the age of the oldest message was incorrectly on the LambdaWorkers DLQ rather than the main queue. This PR moves it to the main queue.

There are tests for this alarm - but they were checking that the alarm was created on the DLQ. The tests have therefore been updated too.