### PR TITLE
fix: plat-5908 add dependency to cdn-site-hosting construct

### DIFF
--- a/lib/cdn-site-hosting/cdn-site-hosting-construct.ts
+++ b/lib/cdn-site-hosting/cdn-site-hosting-construct.ts
@@ -135,6 +135,10 @@ export class CdnSiteHostingConstruct extends cdk.Construct {
         }
       );
 
+      // Give the first deployment a dependency on the s3 bucket. 
+      // Without this, we may start copying files into the s3 bucket before it has been created.
+      deployments[0].node.addDependency(this.s3Bucket);
+      // Now make the rest of the deployments dependent on the previous one.
       deployments.forEach((deployment, deploymentIndex) => {
         if (deploymentIndex > 0) {
           deployment.node.addDependency(deployments[deploymentIndex - 1]);

--- a/lib/cdn-site-hosting/cdn-site-hosting-construct.ts
+++ b/lib/cdn-site-hosting/cdn-site-hosting-construct.ts
@@ -135,7 +135,7 @@ export class CdnSiteHostingConstruct extends cdk.Construct {
         }
       );
 
-      // Give the first deployment a dependency on the s3 bucket. 
+      // Give the first deployment a dependency on the s3 bucket.
       // Without this, we may start copying files into the s3 bucket before it has been created.
       deployments[0].node.addDependency(this.s3Bucket);
       // Now make the rest of the deployments dependent on the previous one.

--- a/test/infra/cdn-site-hosting/cdn-site-hosting-construct.test.ts
+++ b/test/infra/cdn-site-hosting/cdn-site-hosting-construct.test.ts
@@ -303,7 +303,9 @@ describe("CdnSiteHostingConstruct", () => {
       const [[firstDeploymentId, firstDeployment], [, secondDeployment]] =
         deployments;
       expect(firstDeployment.DependsOn).toBeDefined();
-      expect(firstDeployment.DependsOn).toContain('MyTestConstructSiteBucketEE4FFC1B');
+      expect(firstDeployment.DependsOn).toContain(
+        "MyTestConstructSiteBucketEE4FFC1B"
+      );
       expect(secondDeployment.DependsOn).toBeDefined();
       expect(secondDeployment.DependsOn).toContain(firstDeploymentId);
     });

--- a/test/infra/cdn-site-hosting/cdn-site-hosting-construct.test.ts
+++ b/test/infra/cdn-site-hosting/cdn-site-hosting-construct.test.ts
@@ -302,7 +302,8 @@ describe("CdnSiteHostingConstruct", () => {
       expect(deployments.length).toBe(2);
       const [[firstDeploymentId, firstDeployment], [, secondDeployment]] =
         deployments;
-      expect(firstDeployment.DependsOn).toBeUndefined();
+      expect(firstDeployment.DependsOn).toBeDefined();
+      expect(firstDeployment.DependsOn).toContain('MyTestConstructSiteBucketEE4FFC1B');
       expect(secondDeployment.DependsOn).toBeDefined();
       expect(secondDeployment.DependsOn).toContain(firstDeploymentId);
     });


### PR DESCRIPTION
- https://github.com/talis/platform/issues/5908

We have started seeing deployment errors in CA:

![Screenshot from 2022-09-07 12-54-19](https://user-images.githubusercontent.com/232529/188877203-c1af4def-6616-446f-8de9-b0143ad7d92f.png)

These are not happening in the EU region for the same deployment.

We believe the error is being caused by the creation of the bucket taking longer than it has in the past, and the construct starting to sync data with the bucket before it has been created.

This PR adds a dependency to first of the file "deployments" on the s3 bucket, to ensure it is created before the first deployment starts. The other deployments are chained together, with each deployment having  a dependency on the previous one. So these will also not happen before the bucket is created.