### PR TITLE
feat: plat5918 make certificate optional for cdn-site-hosting-with-dns-construct

### DIFF
--- a/test/infra/cdn-site-hosting/cdn-site-hosting-with-dns-construct.test.ts
+++ b/test/infra/cdn-site-hosting/cdn-site-hosting-with-dns-construct.test.ts
@@ -93,6 +93,33 @@ describe("CdnSiteHostingWithDnsConstruct", () => {
     });
   });
 
+  describe("When certificate is provided", () => {
+    let stack: Stack;
+
+    beforeAll(() => {
+      const app = new cdk.App();
+      stack = new cdk.Stack(app, "TestStack", { env: testEnv });
+      new CdnSiteHostingWithDnsConstruct(stack, "MyTestConstruct", {
+        siteSubDomain: fakeSiteSubDomain,
+        domainName: fakeDomain,
+        removalPolicy: RemovalPolicy.DESTROY,
+        sources: [s3deploy.Source.asset("./")],
+        websiteErrorDocument: "error.html",
+        websiteIndexDocument: "index.html",
+        certificateArn: "test-cert",
+      });
+    });
+
+    test("does not provisions a new ACM TLS certificate covering the domain", () => {
+      expectCDK(stack).notTo(
+        haveResourceLike("AWS::CloudFormation::CustomResource", {
+          DomainName: fakeFqdn,
+          Region: "us-east-1",
+        })
+      );
+    });
+  });
+
   describe("When no error document is provided", () => {
     let stack: Stack;
 


### PR DESCRIPTION
- https://github.com/talis/platform/issues/5918

Apps using the `cdn-site-hosting-with-dns-construct` are leaving behind acm validation records in Route 53.

Previously, the construct creates a DNS record, which is itself destroyed when the cloud formation stack is destroyed, however, this process also creates an `acm.validations.aws` route 53 entry outside of the cloud formation stack. This is the record which is never deleted. 

This PR adds an optional certificate to the `cdn-site-hosting-with-dns-construct` props. This will allow applications using it to specify an existing certificate which will not be created and deleted as part of the stack. Doing so will stop the `acm.validations.aws` record from being created in the first place and nothing will be left behind.