### PR TITLE
fix: plat-6457 tfs tags are added to the stack instead of the app

### DIFF
--- a/lib/talis-cdk-stack/talis-cdk-stack.ts
+++ b/lib/talis-cdk-stack/talis-cdk-stack.ts
@@ -14,9 +14,9 @@ export class TalisCdkStack extends Stack {
       this.vpc = this.resolveVpc(props.vpcId);
     }
 
-    cdk.Tags.of(scope).add("tfs-app", props.app); // e.g. depot
-    cdk.Tags.of(scope).add("tfs-environment", props.deploymentEnvironment); // e.g. production staging development
-    cdk.Tags.of(scope).add("tfs-release", props.release); // e.g. 8561-105814f
+    cdk.Tags.of(this).add("tfs-app", props.app); // e.g. depot
+    cdk.Tags.of(this).add("tfs-environment", props.deploymentEnvironment); // e.g. production staging development
+    cdk.Tags.of(this).add("tfs-release", props.release); // e.g. 8561-105814f
 
     // props.env comes from aws cdk core StackProps. It's optional
     // so that an environment agnostic stack can be created.
@@ -32,7 +32,7 @@ export class TalisCdkStack extends Stack {
           `Cannot resolve a tfs-region for props.env.region: '${props.env.region}'`
         );
       }
-      cdk.Tags.of(scope).add("tfs-region", talisShortRegion);
+      cdk.Tags.of(this).add("tfs-region", talisShortRegion);
       let tfsService;
       if (
         props.deploymentEnvironment === TalisDeploymentEnvironment.PRODUCTION
@@ -42,7 +42,7 @@ export class TalisCdkStack extends Stack {
         tfsService = `${props.app}-${props.deploymentEnvironment}-${talisShortRegion}`;
       }
 
-      cdk.Tags.of(scope).add("tfs-service", tfsService);
+      cdk.Tags.of(this).add("tfs-service", tfsService);
     }
   }
 


### PR DESCRIPTION
- https://github.com/talis/platform/issues/6457

On this PR the tags are applied now to the construct instead of to the app scope

from https://docs.aws.amazon.com/cdk/v1/guide/tagging.html
![image](https://user-images.githubusercontent.com/10945557/232788514-0f6f9d7e-ea5a-4664-bb81-65107da27eb8.png)
