### PR TITLE
feat: lambda worker - support container fromImageAsset

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 coverage
 node_modules
 .vscode/
+cdk.out/
 
 # Typescript is our source-code; generated JS and d.ts is left unlinted.
 src/**/*.js

--- a/examples/container-lambda-worker/container/Dockerfile
+++ b/examples/container-lambda-worker/container/Dockerfile
@@ -1,11 +1,10 @@
-FROM public.ecr.aws/lambda/nodejs:14
-# Alternatively, you can pull the base image from Docker Hub: amazon/aws-lambda-nodejs:12
+FROM public.ecr.aws/lambda/nodejs:18.2023.05.13.00
 
-# Assumes your function is named "container-worker.js", and there is a package.json file in the app directory 
-COPY src/lambda/container-worker.js package.json  ${LAMBDA_TASK_ROOT}
+# Assumes your function is named "container-worker.js", and there is a package.json file in the app directory
+COPY container-worker.js package.json ${LAMBDA_TASK_ROOT}
 
 # Install NPM dependencies for function
 RUN npm install
 
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
-CMD [ "container-worker.containerLambdaWorker" ]  
+CMD [ "container-worker.containerLambdaWorker" ]

--- a/examples/container-lambda-worker/container/package.json
+++ b/examples/container-lambda-worker/container/package.json
@@ -2,5 +2,5 @@
   "name": "container-worker",
   "version": "0.1.0",
   "description": "Basic container worker example",
-  "main": "src/lambda/container-worker.js"
+  "main": "container-worker.js"
 }

--- a/examples/container-lambda-worker/lib/container-lambda-worker-stack.ts
+++ b/examples/container-lambda-worker/lib/container-lambda-worker-stack.ts
@@ -1,10 +1,5 @@
 import * as cdk from "@aws-cdk/core";
-import * as ecr from "@aws-cdk/aws-ecr";
 import * as path from "path";
-import { DockerImageAsset } from "@aws-cdk/aws-ecr-assets";
-import * as ecrdeploy from "cdk-ecr-deployment";
-import { v4 as uuidv4 } from "uuid";
-import { RemovalPolicy } from "@aws-cdk/core";
 import * as sns from "@aws-cdk/aws-sns";
 import * as ec2 from "@aws-cdk/aws-ec2";
 
@@ -21,29 +16,6 @@ export class ContainerLambdaWorkerStack extends cdk.Stack {
     const prefix = process.env.AWS_PREFIX
       ? process.env.AWS_PREFIX
       : "development-xx-";
-
-    // LambdaWorker requires an existing ECR Repository to retrieve images from.
-
-    const repository = new ecr.Repository(this, "example-repo", {
-      repositoryName: `${prefix}cdk-container-lambda`,
-      removalPolicy: RemovalPolicy.DESTROY,
-    });
-
-    // LambdaWorker requires an existing image tag within the repository
-    // Build docker image asset from example container Dockerfile
-    const dockerImage = new DockerImageAsset(this, "example-build", {
-      directory: path.join(__dirname, "../container"),
-    });
-    const imageTag = `example-${uuidv4()}`;
-
-    // Currently there is no native CDK support for pushing an image to an ECR repository
-    // AWS recommend using the 'cdk-ecr-deployment' library
-    new ecrdeploy.ECRDeployment(this, "example-ecr-deploy", {
-      src: new ecrdeploy.DockerImageName(dockerImage.imageUri),
-      dest: new ecrdeploy.DockerImageName(
-        repository.repositoryUriForTag(imageTag)
-      ),
-    });
 
     // The LambdaWorker will be triggered by a queue created in the construct.
     // Optionally, you can pass the LambdaWorker a pre-existing topic which
@@ -82,14 +54,16 @@ export class ContainerLambdaWorkerStack extends cdk.Stack {
           environment: {
             EXAMPLE_ENV_VAR: "example value",
           },
-          dockerCommand: "container-worker.containerLambdaWorker",
-          dockerImageTag: imageTag,
-          ecrRepositoryArn: repository.repositoryArn,
-          ecrRepositoryName: repository.repositoryName,
+          imageAsset: {
+            directory: path.join(__dirname, "../container"),
+            props: {
+              cmd: ["container-worker.containerLambdaWorker"],
+            },
+          },
           memorySize: 1024,
           timeout: cdk.Duration.minutes(5),
           vpc: vpc,
-          vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE },
+          vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_NAT },
         },
         queueProps: {
           maxReceiveCount: 3,

--- a/lib/lambda-worker/lambda-worker-props.ts
+++ b/lib/lambda-worker/lambda-worker-props.ts
@@ -4,6 +4,27 @@ import * as iam from "@aws-cdk/aws-iam";
 import * as sns from "@aws-cdk/aws-sns";
 import * as lambda from "@aws-cdk/aws-lambda";
 
+// Lambda properties for different runtimes
+export interface FunctionLambdaProps {
+  handler: string;
+  entry: string;
+}
+
+export interface ContainerFromEcrLambdaProps {
+  ecrRepositoryArn: string;
+  ecrRepositoryName: string;
+  dockerImageTag: string;
+  dockerCommand?: string;
+}
+
+export interface ContainerFromImageAssetLambdaProps {
+  /** Create an ECR image from the specified asset and bind it as the Lambda code */
+  imageAsset: {
+    directory: string;
+    props?: lambda.AssetImageCodeProps;
+  };
+}
+
 export interface LambdaWorkerProps {
   // The name of the LambdaWorker
   name: string;
@@ -12,12 +33,6 @@ export interface LambdaWorkerProps {
   // Documented here https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-lambda-nodejs.NodejsFunctionProps.html
   lambdaProps: {
     description?: string;
-    dockerCommand?: string;
-    dockerImageTag?: string;
-    ecrRepositoryArn?: string;
-    ecrRepositoryName?: string;
-    handler?: string;
-    entry?: string;
     enableQueue?: boolean;
     environment?: { [key: string]: string };
     ephemeralStorageSize?: cdk.Size;
@@ -30,7 +45,9 @@ export interface LambdaWorkerProps {
     timeout: cdk.Duration;
     vpc?: ec2.IVpc;
     vpcSubnets?: ec2.SubnetSelection;
-  };
+  } & Partial<FunctionLambdaProps> &
+    Partial<ContainerFromEcrLambdaProps> &
+    Partial<ContainerFromImageAssetLambdaProps>;
 
   // Queue Properties
   queueProps?: {

--- a/test/infra/lambda-worker/image-assets1/Dockerfile
+++ b/test/infra/lambda-worker/image-assets1/Dockerfile
@@ -1,0 +1,5 @@
+FROM public.ecr.aws/lambda/nodejs:18.2023.05.13.00
+
+COPY app.js ${LAMBDA_TASK_ROOT}
+
+CMD ["app.handler"]

--- a/test/infra/lambda-worker/image-assets2/my.Dockerfile
+++ b/test/infra/lambda-worker/image-assets2/my.Dockerfile
@@ -1,0 +1,6 @@
+FROM public.ecr.aws/lambda/nodejs:18.2023.05.13.00
+
+ARG TEST_ARG
+ENV TEST_ENV_VAR=${TEST_ARG}
+
+COPY app.js ${LAMBDA_TASK_ROOT}


### PR DESCRIPTION
* talis/platform#6511
* Allow creating LambdaWorker's Docker image via `fromImageAsset` - the image will be pushed to `aws-cdk/assets` repository. The image's tag is inferred from the hash of assets used to build the image as well as options used during the build.