### PR TITLE
feat: ele-6855 add preview deploy environment

### DIFF
--- a/lib/talis-cdk-stack/README.md
+++ b/lib/talis-cdk-stack/README.md
@@ -51,6 +51,8 @@ Helper constants to allow us to map and reference our deployment environments
 | BUILD       | Environments spun up for running builds |
 | STAGING     | Staging environment                     |
 | PRODUCTION  | Production Environment                  |
+| ONDEMAND    | On-Demand Environment                   |
+| PREVIEW     | Preview Environment                     |
 
 ### TalisRegions
 

--- a/lib/talis-cdk-stack/talis-cdk-stack.ts
+++ b/lib/talis-cdk-stack/talis-cdk-stack.ts
@@ -57,6 +57,7 @@ export class TalisCdkStack extends Stack {
       case TalisDeploymentEnvironment.STAGING:
         return RemovalPolicy.SNAPSHOT;
       case TalisDeploymentEnvironment.PRODUCTION:
+      case TalisDeploymentEnvironment.PREVIEW:
         return RemovalPolicy.RETAIN;
       default:
         return RemovalPolicy.RETAIN;

--- a/lib/talis-cdk-stack/talis-deployment-environment.ts
+++ b/lib/talis-cdk-stack/talis-deployment-environment.ts
@@ -5,4 +5,5 @@ export enum TalisDeploymentEnvironment {
   STAGING = "staging",
   PRODUCTION = "production",
   ONDEMAND = "ondemand",
+  PREVIEW = "preview",
 }

--- a/test/infra/talis-cdk-stack/talis-cdk-stack.test.ts
+++ b/test/infra/talis-cdk-stack/talis-cdk-stack.test.ts
@@ -37,6 +37,8 @@ describe("Talis CDK Stack", () => {
       [TalisDeploymentEnvironment.TEST, cdk.RemovalPolicy.DESTROY],
       [TalisDeploymentEnvironment.STAGING, cdk.RemovalPolicy.SNAPSHOT],
       [TalisDeploymentEnvironment.PRODUCTION, cdk.RemovalPolicy.RETAIN],
+      [TalisDeploymentEnvironment.PREVIEW, cdk.RemovalPolicy.RETAIN],
+      [TalisDeploymentEnvironment.ONDEMAND, cdk.RemovalPolicy.RETAIN],
     ])(
       "Environment %s should have removal policy of %s",
       (environment, expected) => {
@@ -193,6 +195,11 @@ describe("Talis CDK Stack", () => {
           devEnvironment: TalisDeploymentEnvironment.PRODUCTION,
           region: TalisRegion.EU,
           expectedTfsService: "depot-eu",
+        },
+        {
+          devEnvironment: TalisDeploymentEnvironment.PREVIEW,
+          region: TalisRegion.EU,
+          expectedTfsService: "depot-preview-eu",
         },
       ];
       testcases.forEach((testcase) => {

--- a/test/infra/talis-cdk-stack/talis-deployment-environment.test.ts
+++ b/test/infra/talis-cdk-stack/talis-deployment-environment.test.ts
@@ -7,6 +7,8 @@ describe("Talis Deployment Environments", () => {
     [TalisDeploymentEnvironment.TEST, "test"],
     [TalisDeploymentEnvironment.STAGING, "staging"],
     [TalisDeploymentEnvironment.PRODUCTION, "production"],
+    [TalisDeploymentEnvironment.ONDEMAND, "ondemand"],
+    [TalisDeploymentEnvironment.PREVIEW, "preview"],
   ])(
     "Deployment environment %s should be defined as %s",
     (environment, expected) => {


### PR DESCRIPTION
Otis has a preview environment that uses production primitives.

I have added this environment and set the removal policy to retain as it touches production primitives