### PR TITLE
feat: increase lambda worker default message retention period

### DIFF
--- a/lib/lambda-worker/lambda-worker.ts
+++ b/lib/lambda-worker/lambda-worker.ts
@@ -89,6 +89,7 @@ export class LambdaWorker extends cdk.Construct {
     const lambdaDLQ = new sqs.Queue(this, `${props.name}-dlq`, {
       queueName: dlqName,
       visibilityTimeout: queueTimeout,
+      retentionPeriod: cdk.Duration.days(14),
       fifo: fifo ? true : undefined, // This is required for fifo, but has to be undefined not flase for non-fifo
     });
 
@@ -99,6 +100,7 @@ export class LambdaWorker extends cdk.Construct {
     const lambdaQueue = new sqs.Queue(this, `${props.name}-queue`, {
       queueName,
       visibilityTimeout: queueTimeout,
+      retentionPeriod: cdk.Duration.days(14),
       deadLetterQueue: { queue: lambdaDLQ, maxReceiveCount: maxReceiveCount },
       fifo: fifo ? true : undefined, // This is required for fifo, but has to be undefined not flase for non-fifo
       contentBasedDeduplication:

--- a/test/infra/lambda-worker/lambda-worker.test.ts
+++ b/test/infra/lambda-worker/lambda-worker.test.ts
@@ -90,6 +90,7 @@ describe("LambdaWorker", () => {
           haveResourceLike("AWS::SQS::Queue", {
             QueueName: "MyTestLambdaWorker-queue",
             VisibilityTimeout: 1500, // 5 (default max receive count) * 300 (lambda timeout)
+            MessageRetentionPeriod: 1209600, // 14 days
             RedrivePolicy: {
               maxReceiveCount: 5,
               deadLetterTargetArn: {
@@ -106,6 +107,7 @@ describe("LambdaWorker", () => {
           haveResourceLike("AWS::SQS::Queue", {
             QueueName: "MyTestLambdaWorker-dlq",
             VisibilityTimeout: 1500, // 5 (default max receive count) * 300 (lambda timeout)
+            MessageRetentionPeriod: 1209600, // 14 days
           })
         );
       });


### PR DESCRIPTION
We have been defaulting to 4 days for message retention on SQS queues in the LambdaWorker. This has been the same for both the main queue and the workers DLQ. 

This hasn't caused a problem - the LambdaWorker enforces having an alarm so we always get an alarm if there are messages on the DLQ in production and they are always dealt with in time.

However, in a none production environment recently, we left messages on a DLQ during the August holiday season, assuming the retention period was 14 days. They expired after 4 days. This was not a live environment, so no production issue occurred, but it highlighted that we are still using the default 4 days.

This PR increases the retention period on the queues to the maximum 14 days. There is no reason for this to be set to anything less - especially in production and on DLQ's.

This PR does not make the retention period configurable - it enforces a policy of always using the maximum of 14 days intentionally.