### PR TITLE
chore: plat-6742 upgrade node in lambda-worker and authenticated-api

### DIFF
--- a/lib/authenticated-api/authenticated-api-function.ts
+++ b/lib/authenticated-api/authenticated-api-function.ts
@@ -32,7 +32,7 @@ export class AuthenticatedApiFunction extends lambdaNode.NodejsFunction {
 
       // Enforce the following properties
       awsSdkConnectionReuse: true,
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_16_X,
       timeout: props.timeout,
       securityGroups: props.securityGroups,
       vpc: props.vpc,

--- a/lib/authenticated-api/authenticated-api.ts
+++ b/lib/authenticated-api/authenticated-api.ts
@@ -167,7 +167,7 @@ export class AuthenticatedApi extends cdk.Construct {
         }),
 
         awsSdkConnectionReuse: true,
-        runtime: lambda.Runtime.NODEJS_14_X,
+        runtime: lambda.Runtime.NODEJS_16_X,
         timeout: authLambdaTimeout,
         securityGroups: props.securityGroups,
         vpc: props.vpc,

--- a/lib/lambda-worker/lambda-worker.ts
+++ b/lib/lambda-worker/lambda-worker.ts
@@ -294,7 +294,7 @@ export class LambdaWorker extends cdk.Construct {
 
       // Enforce the following properties
       awsSdkConnectionReuse: true,
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_16_X,
     });
   }
 

--- a/test/infra/authenticated-api/authenticated-api.test.ts
+++ b/test/infra/authenticated-api/authenticated-api.test.ts
@@ -134,7 +134,7 @@ describe("AuthenticatedApi", () => {
           FunctionName: "test-MyTestAuthenticatedApi-authoriser",
           Timeout: 120,
           Handler: "index.validateToken",
-          Runtime: "nodejs14.x",
+          Runtime: "nodejs16.x",
           Environment: {
             Variables: {
               PERSONA_CLIENT_NAME: "test-MyTestAuthenticatedApi-authoriser",
@@ -157,7 +157,7 @@ describe("AuthenticatedApi", () => {
           FunctionName: "test-route1-handler",
           Timeout: 30,
           Handler: "index.route",
-          Runtime: "nodejs14.x",
+          Runtime: "nodejs16.x",
           Environment: {
             Variables: {
               LAMBDA_EXECUTION_TIMEOUT: "30",
@@ -171,7 +171,7 @@ describe("AuthenticatedApi", () => {
           FunctionName: "test-route2-handler",
           Timeout: 30,
           Handler: "index.route",
-          Runtime: "nodejs14.x",
+          Runtime: "nodejs16.x",
           Environment: {
             Variables: {
               LAMBDA_EXECUTION_TIMEOUT: "30",

--- a/test/infra/lambda-worker/lambda-worker.test.ts
+++ b/test/infra/lambda-worker/lambda-worker.test.ts
@@ -58,7 +58,7 @@ describe("LambdaWorker", () => {
             MemorySize: 2048,
             Timeout: 300,
             Handler: "index.testWorker",
-            Runtime: "nodejs14.x",
+            Runtime: "nodejs16.x",
             Environment: {
               Variables: {
                 AWS_NODEJS_CONNECTION_REUSE_ENABLED: "1",
@@ -250,7 +250,7 @@ describe("LambdaWorker", () => {
             MemorySize: 2048,
             Timeout: 300,
             Handler: "index.testWorker",
-            Runtime: "nodejs14.x",
+            Runtime: "nodejs16.x",
             //Optional
             Description: "Test Description",
             Environment: {


### PR DESCRIPTION
- https://github.com/talis/platform/issues/6727
- https://github.com/talis/platform/issues/6742

We have an epic to upgrade lambda's to Node 18. Multiple projects are using this library. The first of which to be picked up in Manifesto which uses both the lambda worker and the authenticated api constructs.

Unfortunately, CDK v1 has now been end of lifed and we can not upgrade past node 16 using it. 

This PR upgrades those two constructs to node 16.