### PR TITLE
fix: plat-6742 restore package.json files section

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,15 @@
 {
   "name": "talis-cdk-constructs",
   "version": "0.1.0",
+  "files": [
+    "lib/**/*.d.ts",
+    "lib/**/*.js",
+    "src/**/*.js",
+    "src/lambda/api/authorizer.ts",
+    "src/lambda/api/authorizer.d.ts"
+  ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "bin": {
     "cdk": "bin/cdk.js"
   },


### PR DESCRIPTION
This PR fixes a problem with the asset zip file created version 3.0

The `files` section from the `package.json` was lost when the project was recreated as a CDK V2 project. This resulted in the wrong files being included in the github release asset zip file.

This PR restores the `files` section.