### PR TITLE
feat(ta-1105): add bundling options to authenticated api

### DIFF
--- a/lib/authenticated-api/authenticated-api-function-props.ts
+++ b/lib/authenticated-api/authenticated-api-function-props.ts
@@ -1,5 +1,6 @@
 import * as cdk from "aws-cdk-lib";
-import { BundlingOptions, aws_ec2 as ec2 } from "aws-cdk-lib";
+import { aws_ec2 as ec2 } from "aws-cdk-lib";
+import { BundlingOptions } from "aws-cdk-lib/aws-lambda-nodejs";
 
 export interface AuthenticatedApiFunctionProps {
   name: string;

--- a/lib/authenticated-api/authenticated-api-function-props.ts
+++ b/lib/authenticated-api/authenticated-api-function-props.ts
@@ -1,5 +1,5 @@
 import * as cdk from "aws-cdk-lib";
-import { aws_ec2 as ec2 } from "aws-cdk-lib";
+import { BundlingOptions, aws_ec2 as ec2 } from "aws-cdk-lib";
 
 export interface AuthenticatedApiFunctionProps {
   name: string;
@@ -11,4 +11,5 @@ export interface AuthenticatedApiFunctionProps {
   vpcSubnets?: ec2.SubnetSelection;
   securityGroups?: Array<ec2.ISecurityGroup>;
   memorySize?: number;
+  bundling?: BundlingOptions;
 }

--- a/lib/authenticated-api/authenticated-api-function.ts
+++ b/lib/authenticated-api/authenticated-api-function.ts
@@ -37,6 +37,7 @@ export class AuthenticatedApiFunction extends lambdaNode.NodejsFunction {
       securityGroups: props.securityGroups,
       vpc: props.vpc,
       vpcSubnets: props.vpcSubnets,
+      bundling: props.bundling,
     });
   }
 }


### PR DESCRIPTION
## Description

* [TA-1105](https://techfromsage.atlassian.net/browse/TA-1105)

Whilst working on the new bookmarking extension API, we need to include `jsdom` in a lambda function. `jsdom` does not bundle correctly and requires extra options to help this along. Currently the `AuthenticatedApiFunction` does not expose the CDK bundling options.

## Change

* Expose the bundling options for an `AuthenticatedApiFunction`

[TA-1105]: https://techfromsage.atlassian.net/browse/TA-1105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ