### PR TITLE
ci: apply TTL-based stack cleanup (PLT-1735)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,20 +12,24 @@ Builds are conducted by CircleCI, and upon successful build of the `main` branch
 ## Available constructs
 
 - CDN Site Hosting constructs
+
   - `CdnSiteHostingConstruct` for static-site or single-page application hosting in S3 via CloudFront.
   - `CdnSiteHostingWithDnsConstruct` for static-site or single-page application hosting in S3 via CloudFront, with DNS record provisioning
 
 - `LambdaWorker`
+
   - A serverless background job.
   - Possible replacement for Resque Workers / Jobs
   - Details [here](/examples/simple-lambda-worker/README.md).
 
 - `AuthenticatedApi`(http api)
+
   - An API Gateway (v2)
   - Built in optional Persona authentication on routes
   - Details [here](/examples/simple-authenticated-api/README.md).
 
 - `AuthenticatedRestApi`(rest api)
+
   - An API Gateway Rest API
   - Built in optional Persona authentication on routes
     - Note: token validation is implemented, but scope validation is not
@@ -38,6 +42,7 @@ Builds are conducted by CircleCI, and upon successful build of the `main` branch
 ## Available Constants
 
 - `TalisRegion`
+
   - Aliases of AWS regions to the regions we deploy applications
   - Details [here](/lib/talis-cdk-stack/README.md)
 

--- a/README.md
+++ b/README.md
@@ -12,24 +12,20 @@ Builds are conducted by CircleCI, and upon successful build of the `main` branch
 ## Available constructs
 
 - CDN Site Hosting constructs
-
   - `CdnSiteHostingConstruct` for static-site or single-page application hosting in S3 via CloudFront.
   - `CdnSiteHostingWithDnsConstruct` for static-site or single-page application hosting in S3 via CloudFront, with DNS record provisioning
 
 - `LambdaWorker`
-
   - A serverless background job.
   - Possible replacement for Resque Workers / Jobs
   - Details [here](/examples/simple-lambda-worker/README.md).
 
 - `AuthenticatedApi`(http api)
-
   - An API Gateway (v2)
   - Built in optional Persona authentication on routes
   - Details [here](/examples/simple-authenticated-api/README.md).
 
 - `AuthenticatedRestApi`(rest api)
-
   - An API Gateway Rest API
   - Built in optional Persona authentication on routes
     - Note: token validation is implemented, but scope validation is not
@@ -42,7 +38,6 @@ Builds are conducted by CircleCI, and upon successful build of the `main` branch
 ## Available Constants
 
 - `TalisRegion`
-
   - Aliases of AWS regions to the regions we deploy applications
   - Details [here](/lib/talis-cdk-stack/README.md)
 

--- a/examples/container-lambda-worker/bin/container-lambda-worker.ts
+++ b/examples/container-lambda-worker/bin/container-lambda-worker.ts
@@ -3,6 +3,10 @@ import "source-map-support/register";
 import * as cdk from "aws-cdk-lib";
 import { ContainerLambdaWorkerStack } from "../lib/container-lambda-worker-stack";
 
+const buildStackTtl = Math.floor(
+  (Date.now() + cdk.Duration.days(3).toMilliseconds()) / 1000,
+).toString();
+
 const app = new cdk.App();
 new ContainerLambdaWorkerStack(
   app,
@@ -11,6 +15,10 @@ new ContainerLambdaWorkerStack(
     env: {
       account: process.env.CDK_DEFAULT_ACCOUNT,
       region: process.env.CDK_DEFAULT_REGION,
+    },
+    tags: {
+      // Auto-expire this stack if created by a build system
+      ...(process.env.CI ? { ttl: buildStackTtl } : undefined),
     },
   },
 );

--- a/examples/simple-authenticated-api/bin/simple-authenticated-api.ts
+++ b/examples/simple-authenticated-api/bin/simple-authenticated-api.ts
@@ -3,6 +3,10 @@ import "source-map-support/register";
 import * as cdk from "aws-cdk-lib";
 import { SimpleAuthenticatedApiStack } from "../lib/simple-authenticated-api-stack";
 
+const buildStackTtl = Math.floor(
+  (Date.now() + cdk.Duration.days(3).toMilliseconds()) / 1000,
+).toString();
+
 const app = new cdk.App();
 new SimpleAuthenticatedApiStack(
   app,
@@ -11,6 +15,10 @@ new SimpleAuthenticatedApiStack(
     env: {
       account: process.env.CDK_DEFAULT_ACCOUNT,
       region: process.env.CDK_DEFAULT_REGION,
+    },
+    tags: {
+      // Auto-expire this stack if created by a build system
+      ...(process.env.CI ? { ttl: buildStackTtl } : undefined),
     },
   },
 );

--- a/examples/simple-authenticated-rest-api/bin/simple-authenticated-rest-api.ts
+++ b/examples/simple-authenticated-rest-api/bin/simple-authenticated-rest-api.ts
@@ -3,6 +3,10 @@ import "source-map-support/register";
 import * as cdk from "aws-cdk-lib";
 import { SimpleAuthenticatedRestApiStack } from "../lib/simple-authenticated-rest-api-stack";
 
+const buildStackTtl = Math.floor(
+  (Date.now() + cdk.Duration.days(3).toMilliseconds()) / 1000,
+).toString();
+
 const app = new cdk.App();
 new SimpleAuthenticatedRestApiStack(
   app,
@@ -11,6 +15,10 @@ new SimpleAuthenticatedRestApiStack(
     env: {
       account: process.env.CDK_DEFAULT_ACCOUNT,
       region: process.env.CDK_DEFAULT_REGION,
+    },
+    tags: {
+      // Auto-expire this stack if created by a build system
+      ...(process.env.CI ? { ttl: buildStackTtl } : undefined),
     },
   },
 );

--- a/examples/simple-cdn-site-hosting-construct/bin/simple-cdn-site-hosting-construct.ts
+++ b/examples/simple-cdn-site-hosting-construct/bin/simple-cdn-site-hosting-construct.ts
@@ -3,6 +3,10 @@ import "source-map-support/register";
 import * as cdk from "aws-cdk-lib";
 import { SimpleCdnSiteHostingConstructStack } from "../lib/simple-cdn-site-hosting-construct-stack";
 
+const buildStackTtl = Math.floor(
+  (Date.now() + cdk.Duration.days(3).toMilliseconds()) / 1000,
+).toString();
+
 const app = new cdk.App();
 new SimpleCdnSiteHostingConstructStack(
   app,
@@ -11,6 +15,10 @@ new SimpleCdnSiteHostingConstructStack(
     env: {
       account: process.env.CDK_DEFAULT_ACCOUNT,
       region: process.env.CDK_DEFAULT_REGION,
+    },
+    tags: {
+      // Auto-expire this stack if created by a build system
+      ...(process.env.CI ? { ttl: buildStackTtl } : undefined),
     },
   },
 );

--- a/examples/simple-lambda-worker/bin/simple-lambda-worker.ts
+++ b/examples/simple-lambda-worker/bin/simple-lambda-worker.ts
@@ -3,6 +3,10 @@ import "source-map-support/register";
 import * as cdk from "aws-cdk-lib";
 import { SimpleLambdaWorkerStack } from "../lib/simple-lambda-worker-stack";
 
+const buildStackTtl = Math.floor(
+  (Date.now() + cdk.Duration.days(3).toMilliseconds()) / 1000,
+).toString();
+
 const app = new cdk.App();
 new SimpleLambdaWorkerStack(
   app,
@@ -11,6 +15,10 @@ new SimpleLambdaWorkerStack(
     env: {
       account: process.env.CDK_DEFAULT_ACCOUNT,
       region: process.env.CDK_DEFAULT_REGION,
+    },
+    tags: {
+      // Auto-expire this stack if created by a build system
+      ...(process.env.CI ? { ttl: buildStackTtl } : undefined),
     },
   },
 );

--- a/examples/simple-talis-cdk-stack/bin/simple-talis-cdk-stack.ts
+++ b/examples/simple-talis-cdk-stack/bin/simple-talis-cdk-stack.ts
@@ -4,6 +4,10 @@ import * as cdk from "aws-cdk-lib";
 import { SimpleTalisCdkStack } from "../lib/simple-talis-cdk-stack";
 import { TalisDeploymentEnvironment } from "../../../lib";
 
+const buildStackTtl = Math.floor(
+  (Date.now() + cdk.Duration.days(3).toMilliseconds()) / 1000,
+).toString();
+
 const app = new cdk.App();
 new SimpleTalisCdkStack(
   app,
@@ -15,6 +19,10 @@ new SimpleTalisCdkStack(
     env: {
       account: process.env.CDK_DEFAULT_ACCOUNT,
       region: process.env.CDK_DEFAULT_REGION,
+    },
+    tags: {
+      // Auto-expire this stack if created by a build system
+      ...(process.env.CI ? { ttl: buildStackTtl } : undefined),
     },
   },
 );


### PR DESCRIPTION
- [PLT-1735](https://techfromsage.atlassian.net/browse/PLT-1735)
- Add `ttl` tag to example stacks when deployed from CI to allow for auto cleanup.

[PLT-1735]: https://techfromsage.atlassian.net/browse/PLT-1735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ