### PR TITLE
ci: add env=build tag to example stacks in CI (PLT-1735)

### DIFF
--- a/examples/container-lambda-worker/bin/container-lambda-worker.ts
+++ b/examples/container-lambda-worker/bin/container-lambda-worker.ts
@@ -2,9 +2,10 @@
 import "source-map-support/register";
 import * as cdk from "aws-cdk-lib";
 import { ContainerLambdaWorkerStack } from "../lib/container-lambda-worker-stack";
+import { TalisDeploymentEnvironment } from "../../../lib";
 
 const buildStackTtl = Math.floor(
-  (Date.now() + cdk.Duration.days(3).toMilliseconds()) / 1000,
+  (Date.now() + cdk.Duration.days(3).toMilliseconds()) / 1000
 ).toString();
 
 const app = new cdk.App();
@@ -18,7 +19,9 @@ new ContainerLambdaWorkerStack(
     },
     tags: {
       // Auto-expire this stack if created by a build system
-      ...(process.env.CI ? { ttl: buildStackTtl } : undefined),
+      ...(process.env.CI
+        ? { env: TalisDeploymentEnvironment.BUILD, ttl: buildStackTtl }
+        : undefined),
     },
-  },
+  }
 );

--- a/examples/container-lambda-worker/bin/container-lambda-worker.ts
+++ b/examples/container-lambda-worker/bin/container-lambda-worker.ts
@@ -5,7 +5,7 @@ import { ContainerLambdaWorkerStack } from "../lib/container-lambda-worker-stack
 import { TalisDeploymentEnvironment } from "../../../lib";
 
 const buildStackTtl = Math.floor(
-  (Date.now() + cdk.Duration.days(3).toMilliseconds()) / 1000
+  (Date.now() + cdk.Duration.days(3).toMilliseconds()) / 1000,
 ).toString();
 
 const app = new cdk.App();
@@ -23,5 +23,5 @@ new ContainerLambdaWorkerStack(
         ? { env: TalisDeploymentEnvironment.BUILD, ttl: buildStackTtl }
         : undefined),
     },
-  }
+  },
 );

--- a/examples/simple-authenticated-api/bin/simple-authenticated-api.ts
+++ b/examples/simple-authenticated-api/bin/simple-authenticated-api.ts
@@ -2,6 +2,7 @@
 import "source-map-support/register";
 import * as cdk from "aws-cdk-lib";
 import { SimpleAuthenticatedApiStack } from "../lib/simple-authenticated-api-stack";
+import { TalisDeploymentEnvironment } from "../../../lib";
 
 const buildStackTtl = Math.floor(
   (Date.now() + cdk.Duration.days(3).toMilliseconds()) / 1000,
@@ -18,7 +19,9 @@ new SimpleAuthenticatedApiStack(
     },
     tags: {
       // Auto-expire this stack if created by a build system
-      ...(process.env.CI ? { ttl: buildStackTtl } : undefined),
+      ...(process.env.CI
+        ? { env: TalisDeploymentEnvironment.BUILD, ttl: buildStackTtl }
+        : undefined),
     },
   },
 );

--- a/examples/simple-authenticated-rest-api/bin/simple-authenticated-rest-api.ts
+++ b/examples/simple-authenticated-rest-api/bin/simple-authenticated-rest-api.ts
@@ -2,6 +2,7 @@
 import "source-map-support/register";
 import * as cdk from "aws-cdk-lib";
 import { SimpleAuthenticatedRestApiStack } from "../lib/simple-authenticated-rest-api-stack";
+import { TalisDeploymentEnvironment } from "../../../lib";
 
 const buildStackTtl = Math.floor(
   (Date.now() + cdk.Duration.days(3).toMilliseconds()) / 1000,
@@ -18,7 +19,9 @@ new SimpleAuthenticatedRestApiStack(
     },
     tags: {
       // Auto-expire this stack if created by a build system
-      ...(process.env.CI ? { ttl: buildStackTtl } : undefined),
+      ...(process.env.CI
+        ? { env: TalisDeploymentEnvironment.BUILD, ttl: buildStackTtl }
+        : undefined),
     },
   },
 );

--- a/examples/simple-cdn-site-hosting-construct/bin/simple-cdn-site-hosting-construct.ts
+++ b/examples/simple-cdn-site-hosting-construct/bin/simple-cdn-site-hosting-construct.ts
@@ -2,6 +2,7 @@
 import "source-map-support/register";
 import * as cdk from "aws-cdk-lib";
 import { SimpleCdnSiteHostingConstructStack } from "../lib/simple-cdn-site-hosting-construct-stack";
+import { TalisDeploymentEnvironment } from "../../../lib";
 
 const buildStackTtl = Math.floor(
   (Date.now() + cdk.Duration.days(3).toMilliseconds()) / 1000,
@@ -18,7 +19,9 @@ new SimpleCdnSiteHostingConstructStack(
     },
     tags: {
       // Auto-expire this stack if created by a build system
-      ...(process.env.CI ? { ttl: buildStackTtl } : undefined),
+      ...(process.env.CI
+        ? { env: TalisDeploymentEnvironment.BUILD, ttl: buildStackTtl }
+        : undefined),
     },
   },
 );

--- a/examples/simple-lambda-worker/bin/simple-lambda-worker.ts
+++ b/examples/simple-lambda-worker/bin/simple-lambda-worker.ts
@@ -2,6 +2,7 @@
 import "source-map-support/register";
 import * as cdk from "aws-cdk-lib";
 import { SimpleLambdaWorkerStack } from "../lib/simple-lambda-worker-stack";
+import { TalisDeploymentEnvironment } from "../../../lib";
 
 const buildStackTtl = Math.floor(
   (Date.now() + cdk.Duration.days(3).toMilliseconds()) / 1000,
@@ -18,7 +19,9 @@ new SimpleLambdaWorkerStack(
     },
     tags: {
       // Auto-expire this stack if created by a build system
-      ...(process.env.CI ? { ttl: buildStackTtl } : undefined),
+      ...(process.env.CI
+        ? { env: TalisDeploymentEnvironment.BUILD, ttl: buildStackTtl }
+        : undefined),
     },
   },
 );


### PR DESCRIPTION
- Correction for #119
- Most examples don't use TalisCdkStack, so have no `tfs-` tags applied